### PR TITLE
Making matrix and vector data private.

### DIFF
--- a/rusty-machine/src/learning/gp.rs
+++ b/rusty-machine/src/learning/gp.rs
@@ -132,8 +132,8 @@ impl<T: Kernel, U: MeanFunc> GaussianProcess<T, U> {
 
         for i in 0..dim1 {
             for j in 0..dim2 {
-                ker_data.push(self.ker.kernel(&m1.data[i * m1.cols()..(i + 1) * m1.cols()],
-                                              &m2.data[j * m2.cols()..(j + 1) * m2.cols()]));
+                ker_data.push(self.ker.kernel(&m1.data()[i * m1.cols()..(i + 1) * m1.cols()],
+                                              &m2.data()[j * m2.cols()..(j + 1) * m2.cols()]));
             }
         }
 

--- a/rusty-machine/src/learning/nnet.rs
+++ b/rusty-machine/src/learning/nnet.rs
@@ -249,7 +249,7 @@ impl<'a, T: Criterion> NeuralNet<'a, T> {
         let mut gradients = Vec::with_capacity(capacity);
 
         for g in grad {
-            gradients.append(&mut g.data.clone());
+            gradients.append(&mut g.data().clone());
         }
 
         (self.criterion.cost(&activations[activations.len() - 1], outputs), gradients)

--- a/rusty-machine/src/learning/optim/fmincg.rs
+++ b/rusty-machine/src/learning/optim/fmincg.rs
@@ -60,7 +60,7 @@ impl<M: Optimizable> OptimAlgorithm<M> for ConjugateGD {
 
             x = x + &s * z1;
 
-            let cost = model.compute_grad(&x.data[..], data, outputs);
+            let cost = model.compute_grad(&x.data()[..], data, outputs);
             f2 = cost.0;
             df2 = Vector::new(cost.1);
 
@@ -115,7 +115,7 @@ impl<M: Optimizable> OptimAlgorithm<M> for ConjugateGD {
 
                     z1 = z1 + z2;
                     x = x + &s * z2;
-                    let cost_grad = model.compute_grad(&x.data[..], data, outputs);
+                    let cost_grad = model.compute_grad(&x.data()[..], data, outputs);
                     f2 =  cost_grad.0;
                     df2 = Vector::new(cost_grad.1);
 
@@ -163,7 +163,7 @@ impl<M: Optimizable> OptimAlgorithm<M> for ConjugateGD {
                 z1 = z1 + z2;
                 x = x + &s * z2;
 
-                let cost_grad = model.compute_grad(&x.data[..], data, outputs);
+                let cost_grad = model.compute_grad(&x.data()[..], data, outputs);
                 f2 =  cost_grad.0;
                 df2 = Vector::new(cost_grad.1);
 
@@ -215,6 +215,6 @@ impl<M: Optimizable> OptimAlgorithm<M> for ConjugateGD {
             }
 
         }
-        x.data
+        x.into_vec()
     }
 }

--- a/rusty-machine/src/learning/optim/grad_desc.rs
+++ b/rusty-machine/src/learning/optim/grad_desc.rs
@@ -58,8 +58,8 @@ impl<M: Optimizable> OptimAlgorithm<M> for GradientDesc {
 		let mut optimizing_val = Vector::new(start.to_vec());
 
 		for _i in 0..self.iters {
-			optimizing_val = optimizing_val.clone() - Vector::new(model.compute_grad(&optimizing_val.data[..], data, outputs).1) * self.alpha;
+			optimizing_val = &optimizing_val - Vector::new(model.compute_grad(&optimizing_val.data()[..], data, outputs).1) * self.alpha;
 		}
-		optimizing_val.data
+		optimizing_val.into_vec()
 	}
 } 

--- a/rusty-machine/src/linalg/matrix.rs
+++ b/rusty-machine/src/linalg/matrix.rs
@@ -16,9 +16,7 @@ use linalg::utils;
 pub struct Matrix<T> {
     rows: usize,
     cols: usize,
-    /// The underlying matrix data.
-    /// NOTE: This should not be changed after instantiation.
-    pub data: Vec<T>,
+    data: Vec<T>,
 }
 
 impl<T> Matrix<T> {
@@ -54,6 +52,14 @@ impl<T> Matrix<T> {
     /// Returns the number of columns in the Matrix.
     pub fn cols(&self) -> usize {
         self.cols
+    }
+
+    pub fn data(&self) -> &Vec<T> {
+        &self.data
+    }
+
+    pub fn into_vec(self) -> Vec<T> {
+        self.data
     }
 }
 
@@ -241,9 +247,9 @@ impl<T: Copy> Matrix<T> {
     /// let e = &b.diag(); // 1,4
     /// let f = &c.diag(); // 1,5
     ///
-    /// assert_eq!(d.data, vec![1,5,9]);
-    /// assert_eq!(e.data, vec![1,4]);
-    /// assert_eq!(f.data, vec![1,5]);
+    /// assert_eq!(*d.data(), vec![1,5,9]);
+    /// assert_eq!(*e.data(), vec![1,4]);
+    /// assert_eq!(*f.data(), vec![1,5]);
     /// ```
     pub fn diag(&self) -> Vector<T> {
         let mat_min = min(self.rows, self.cols);
@@ -271,7 +277,7 @@ impl<T: Copy> Matrix<T> {
     ///
     /// let b = a.apply(&add_two);
     ///
-    /// assert_eq!(b.data, vec![2.0; 4]);
+    /// assert_eq!(*b.data(), vec![2.0; 4]);
     /// ```
     pub fn apply(self, f: &Fn(T) -> T) -> Matrix<T> {
         let new_data = self.data.into_iter().map(|v| f(v)).collect();
@@ -448,7 +454,7 @@ impl<T: Copy + Zero + One + Add<T, Output = T>> Matrix<T> {
     /// let a = Matrix::new(2,2,vec![1.0,2.0,3.0,4.0]);
     ///
     /// let c = a.sum_rows();
-    /// assert_eq!(c.data, vec![4.0, 6.0]);
+    /// assert_eq!(*c.data(), vec![4.0, 6.0]);
     /// ```
     pub fn sum_rows(&self) -> Vector<T> {
         let mut row_sum = vec![T::zero(); self.cols];
@@ -475,7 +481,7 @@ impl<T: Copy + Zero + One + Add<T, Output = T>> Matrix<T> {
     /// let a = Matrix::new(2,2,vec![1.0,2.0,3.0,4.0]);
     ///
     /// let c = a.sum_cols();
-    /// assert_eq!(c.data, vec![3.0, 7.0]);
+    /// assert_eq!(*c.data(), vec![3.0, 7.0]);
     /// ```
     pub fn sum_cols(&self) -> Vector<T> {
         let mut col_sum = vec![T::zero(); self.rows];
@@ -528,7 +534,7 @@ impl<T: Copy + Zero + Mul<T, Output = T>> Matrix<T> {
     /// let b = Matrix::new(2,2,vec![1.0,2.0,3.0,4.0]);
     ///
     /// let c = &a.elemul(&b);
-    /// assert_eq!(c.data, vec![1.0, 4.0, 9.0, 16.0]);
+    /// assert_eq!(*c.data(), vec![1.0, 4.0, 9.0, 16.0]);
     /// ```
     pub fn elemul(&self, m: &Matrix<T>) -> Matrix<T> {
         assert!(self.rows==m.rows, "Matrix row counts not equal.");
@@ -550,7 +556,7 @@ impl<T: Copy + Zero + Div<T, Output = T>> Matrix<T> {
     /// let b = Matrix::new(2,2,vec![1.0,2.0,3.0,4.0]);
     ///
     /// let c = &a.elediv(&b);
-    /// assert_eq!(c.data, vec![1.0; 4]);
+    /// assert_eq!(*c.data(), vec![1.0; 4]);
     /// ```
     pub fn elediv(&self, m: &Matrix<T>) -> Matrix<T> {
         assert!(self.rows==m.rows, "Matrix row counts not equal.");
@@ -574,10 +580,10 @@ impl<T: Copy + Zero + Float + FromPrimitive> Matrix<T> {
     /// let a = Matrix::<f64>::new(2,2, vec![1.0,2.0,3.0,4.0]);
     ///
     /// let c = a.mean(0);
-    /// assert_eq!(c.data, vec![2.0, 3.0]);
+    /// assert_eq!(*c.data(), vec![2.0, 3.0]);
     ///
     /// let d = a.mean(1);
-    /// assert_eq!(d.data, vec![1.5, 3.5]);
+    /// assert_eq!(*d.data(), vec![1.5, 3.5]);
     /// ```
     pub fn mean(&self, axis: usize) -> Vector<T> {
         let m: Vector<T>;
@@ -609,10 +615,10 @@ impl<T: Copy + Zero + Float + FromPrimitive> Matrix<T> {
     /// let a = Matrix::<f32>::new(2,2,vec![1.0,2.0,3.0,4.0]);
     ///
     /// let c = a.variance(0);
-    /// assert_eq!(c.data, vec![2.0, 2.0]);
+    /// assert_eq!(*c.data(), vec![2.0, 2.0]);
     ///
     /// let d = a.variance(1);
-    /// assert_eq!(d.data, vec![0.5, 0.5]);
+    /// assert_eq!(*d.data(), vec![0.5, 0.5]);
     /// ```
     pub fn variance(&self, axis: usize) -> Vector<T> {
         let mean = self.mean(axis);
@@ -716,7 +722,7 @@ impl<T> Matrix<T> where T: Copy + One + Zero + Neg<Output=T> +
     ///
     /// let x = a.solve(y);
     ///
-    /// assert_eq!(x.data, vec![2.0, 3.0]);
+    /// assert_eq!(*x.data(), vec![2.0, 3.0]);
     /// ```
     pub fn solve(&self, y: Vector<T>) -> Vector<T> {
         let (l,u,p) = self.lup_decomp();
@@ -737,7 +743,7 @@ impl<T> Matrix<T> where T: Copy + One + Zero + Neg<Output=T> +
     ///
     /// let I = a * inv;
     ///
-    /// assert_eq!(I.data, vec![1.0,0.0,0.0,1.0]);
+    /// assert_eq!(*I.data(), vec![1.0,0.0,0.0,1.0]);
     /// ```
     pub fn inverse(&self) -> Matrix<T> {
         assert!(self.rows==self.cols, "Matrix is not square.");
@@ -763,7 +769,7 @@ impl<T> Matrix<T> where T: Copy + One + Zero + Neg<Output=T> +
             id_col[i] = T::one();
 
             let b = l.solve_l_triangular(&p * Vector::new(id_col));
-            new_t_data.append(&mut u.solve_u_triangular(b).data);
+            new_t_data.append(&mut u.solve_u_triangular(b).into_vec());
 
         }
 
@@ -1125,7 +1131,7 @@ impl<'a, 'b, T: Copy + One + Zero + Mul<T, Output=T> + Add<T, Output=T>> Mul<&'b
 
         for i in 0..self.rows
         {
-            new_data[i] = utils::dot(&self.data[i*self.cols..(i+1)*self.cols], &v.data);
+            new_data[i] = utils::dot(&self.data[i*self.cols..(i+1)*self.cols], v.data());
         }
 
         return Vector::new(new_data)

--- a/rusty-machine/src/linalg/matrix.rs
+++ b/rusty-machine/src/linalg/matrix.rs
@@ -54,10 +54,12 @@ impl<T> Matrix<T> {
         self.cols
     }
 
+    /// Returns a non-mutable reference to the underlying data.
     pub fn data(&self) -> &Vec<T> {
         &self.data
     }
 
+    /// Consumes the Matrix and returns the Vec of data.
     pub fn into_vec(self) -> Vec<T> {
         self.data
     }

--- a/rusty-machine/src/linalg/vector.rs
+++ b/rusty-machine/src/linalg/vector.rs
@@ -16,7 +16,7 @@ pub struct Vector<T> {
     size: usize,
     /// The underlying vector data.
     /// NOTE: This should not be changed after instantiation.
-    pub data: Vec<T>,
+    data: Vec<T>,
 }
 
 impl<T> Vector<T> {
@@ -45,6 +45,14 @@ impl<T> Vector<T> {
     pub fn size(&self) -> usize {
         self.size
     }
+
+    pub fn data(&self) -> &Vec<T> {
+        &self.data
+    }
+
+    pub fn into_vec(self) -> Vec<T> {
+        self.data
+    }
 }
 
 impl<T: Clone> Clone for Vector<T> {
@@ -71,7 +79,7 @@ impl<T: Copy> Vector<T> {
     ///
     /// let b = a.apply(&add_two);
     ///
-    /// assert_eq!(b.data, vec![2.0; 4]);
+    /// assert_eq!(b.into_vec(), vec![2.0; 4]);
     /// ```
     pub fn apply(self, f: &Fn(T) -> T) -> Vector<T> {
         let new_data = self.data.into_iter().map(|v| f(v)).collect();
@@ -212,7 +220,7 @@ impl<T: Copy + Zero + Mul<T, Output = T>> Vector<T> {
     /// let b = Vector::new(vec![1.0,2.0,3.0,4.0]);
     ///
     /// let c = &a.elemul(&b);
-    /// assert_eq!(c.data, vec![1.0, 4.0, 9.0, 16.0]);
+    /// assert_eq!(*c.data(), vec![1.0, 4.0, 9.0, 16.0]);
     /// ```
     pub fn elemul(&self, v: &Vector<T>) -> Vector<T> {
         assert_eq!(self.size, v.size);
@@ -232,7 +240,7 @@ impl<T: Copy + Zero + Div<T, Output = T>> Vector<T> {
     /// let b = Vector::new(vec![1.0,2.0,3.0,4.0]);
     ///
     /// let c = &a.elediv(&b);
-    /// assert_eq!(c.data, vec![1.0; 4]);
+    /// assert_eq!(*c.data(), vec![1.0; 4]);
     /// ```
     pub fn elediv(&self, v: &Vector<T>) -> Vector<T> {
         assert_eq!(self.size, v.size);
@@ -257,7 +265,7 @@ impl<T: Copy + Zero + Float + FromPrimitive> Vector<T> {
     /// ```
     pub fn mean(&self) -> T {
         let sum = self.sum();
-        sum / FromPrimitive::from_usize(self.data.len()).unwrap()
+        sum / FromPrimitive::from_usize(self.size()).unwrap()
     }
 
     /// The variance of the vector.
@@ -282,7 +290,7 @@ impl<T: Copy + Zero + Float + FromPrimitive> Vector<T> {
             var = var + (*u - m) * (*u - m);
         }
 
-        var / FromPrimitive::from_usize(self.data.len() - 1).unwrap()
+        var / FromPrimitive::from_usize(self.size() - 1).unwrap()
     }
 }
 

--- a/rusty-machine/src/linalg/vector.rs
+++ b/rusty-machine/src/linalg/vector.rs
@@ -14,8 +14,6 @@ use linalg::utils;
 /// Can be instantiated with any type.
 pub struct Vector<T> {
     size: usize,
-    /// The underlying vector data.
-    /// NOTE: This should not be changed after instantiation.
     data: Vec<T>,
 }
 
@@ -46,10 +44,12 @@ impl<T> Vector<T> {
         self.size
     }
 
+    /// Returns a non-mutable reference to the underlying data.
     pub fn data(&self) -> &Vec<T> {
         &self.data
     }
 
+    /// Consumes the Vector and returns the Vec of data.
     pub fn into_vec(self) -> Vec<T> {
         self.data
     }

--- a/rusty-machine/tests/learning/k_means.rs
+++ b/rusty-machine/tests/learning/k_means.rs
@@ -13,7 +13,7 @@ fn test_model_default() {
 
     let a = model.predict(&pred_data);
 
-    assert_eq!(a.data.len(), 3);
+    assert_eq!(a.size(), 3);
 }
 
 #[test]
@@ -27,7 +27,7 @@ fn test_model_iter() {
 
     let a = model.predict(&pred_data);
 
-    assert_eq!(a.data.len(), 3);
+    assert_eq!(a.size(), 3);
 }
 
 #[test]
@@ -41,7 +41,7 @@ fn test_model_forgy() {
 
     let a = model.predict(&pred_data);
 
-    assert_eq!(a.data.len(), 3);
+    assert_eq!(a.size(), 3);
 }
 
 #[test]
@@ -55,7 +55,7 @@ fn test_model_ran_partition() {
 
     let a = model.predict(&pred_data);
 
-    assert_eq!(a.data.len(), 3);
+    assert_eq!(a.size(), 3);
 }
 
 #[test]
@@ -69,5 +69,5 @@ fn test_model_kplusplus() {
 
     let a = model.predict(&pred_data);
 
-    assert_eq!(a.data.len(), 3);
+    assert_eq!(a.size(), 3);
 }

--- a/rusty-machine/tests/linalg/mat.rs
+++ b/rusty-machine/tests/linalg/mat.rs
@@ -218,9 +218,9 @@ fn matrix_lup_decomp() {
     let u_true = vec![2., 4., 7., 0., 1., 1.5, 0., 0., -2.];
     let p_true = vec![0., 1., 0., 1., 0., 0., 0., 0., 1.];
 
-    assert_eq!(p.data, p_true);
-    assert_eq!(l.data, l_true);
-    assert_eq!(u.data, u_true);
+    assert_eq!(*p.data(), p_true);
+    assert_eq!(*l.data(), l_true);
+    assert_eq!(*u.data(), u_true);
 
     let e = Matrix::<f64>::new(5,
                                5,
@@ -231,8 +231,8 @@ fn matrix_lup_decomp() {
     let k = p.transpose() * l * u;
 
     for i in 0..25 {
-        println!("{0},{1}", e.data[i], k.data[i]);
-        assert_eq!(e.data[i], k.data[i]);
+        println!("{0},{1}", e.data()[i], k.data()[i]);
+        assert_eq!(e.data()[i], k.data()[i]);
     }
 }
 
@@ -294,5 +294,5 @@ fn cholesky() {
 
     let l = a.cholesky();
 
-    assert_eq!(l.data, vec![5.,0.,0.,3.,3.,0.,-1.,1.,3.]);
+    assert_eq!(*l.data(), vec![5.,0.,0.,3.,3.,0.,-1.,1.,3.]);
 }


### PR DESCRIPTION
This PR will resolve issue #1 by making the current data field private. This PR includes two new methods:

- data() : a public method returning a reference to the underlying data.
- into_vec() : a public method which consumes self and returns the underlying data.