### PR TITLE
derive Debug for Matrix and Vector

### DIFF
--- a/rusty-machine/src/linalg/matrix/mod.rs
+++ b/rusty-machine/src/linalg/matrix/mod.rs
@@ -15,6 +15,7 @@ mod decomposition;
 /// The Matrix struct.
 ///
 /// Can be instantiated with any type.
+#[derive(Debug)]
 pub struct Matrix<T> {
     rows: usize,
     cols: usize,

--- a/rusty-machine/src/linalg/vector.rs
+++ b/rusty-machine/src/linalg/vector.rs
@@ -12,6 +12,7 @@ use linalg::utils;
 /// The Vector struct.
 ///
 /// Can be instantiated with any type.
+#[derive(Debug)]
 pub struct Vector<T> {
     size: usize,
     data: Vec<T>,


### PR DESCRIPTION
The [std::fmt documentation recommends](https://doc.rust-lang.org/std/fmt/#fmtdisplay-vs-fmtdebug) implementing a faithful representation of internal state for all public types.

Consider the following program.
``` rust
extern crate rusty_machine;

use rusty_machine::linalg::matrix::Matrix;
use rusty_machine::linalg::vector::Vector;

fn main() {
    let my_first_matrix = Matrix::new(2, 3, vec![1, 2, 3, 4, 5, 6]);
    let my_first_vector = Vector::new(vec![1, 2, 3, 4]);
    println!("{:?}", my_first_matrix);
    println!("{:?}", my_first_vector);
}
```
**On master:**
*[fails to compile]*
```
src/main.rs:9:22: 9:37 error: the trait `core::fmt::Debug` is not implemented for the type `rusty_machine::linalg::matrix::Matrix<_>` [E0277]
src/main.rs:9     println!("{:?}", my_first_matrix);
                                   ^~~~~~~~~~~~~~~
[redacted for brevity ...]
src/main.rs:10:22: 10:37 error: the trait `core::fmt::Debug` is not implemented for the type `rusty_machine::linalg::vector::Vector<_>` [E0277]
src/main.rs:10     println!("{:?}", my_first_vector);

```

**Output with this patch:**
```
Matrix { rows: 2, cols: 3, data: [1, 2, 3, 4, 5, 6] }
Vector { size: 4, data: [1, 2, 3, 4] }
```