### PR TITLE
Derive the World

### DIFF
--- a/rusty-machine/src/learning/glm.rs
+++ b/rusty-machine/src/learning/glm.rs
@@ -45,6 +45,7 @@ use learning::SupModel;
 /// The model is generic over a Criterion
 /// which specifies the distribution family and
 /// the link function.
+#[derive(Debug)]
 pub struct GenLinearModel<C: Criterion> {
     parameters: Option<Vector<f64>>,
     criterion: C,
@@ -220,6 +221,7 @@ pub trait LinkFunc {
 /// The Logit link function.
 ///
 /// Used primarily as the canonical link in Binomial Regression.
+#[derive(Debug)]
 pub struct Logit;
 
 /// The Logit link function.
@@ -243,6 +245,7 @@ impl LinkFunc for Logit {
 /// The log link function.
 ///
 /// Used primarily as the canonical link in Poisson Regression.
+#[derive(Debug)]
 pub struct Log;
 
 /// The log link function.
@@ -265,6 +268,7 @@ impl LinkFunc for Log {
 /// The Identity link function.
 ///
 /// Used primarily as the canonical link in Linear Regression.
+#[derive(Debug)]
 pub struct Identity;
 
 /// The Identity link function.
@@ -287,6 +291,7 @@ impl LinkFunc for Identity {
 /// The Bernoulli regression family.
 ///
 /// This is equivalent to logistic regression.
+#[derive(Debug)]
 pub struct Bernoulli;
 
 impl Criterion for Bernoulli {
@@ -354,6 +359,7 @@ impl Criterion for Bernoulli {
 }
 
 /// The Binomial regression family.
+#[derive(Debug)]
 pub struct Binomial {
     weights: Vec<f64>,
 }
@@ -426,6 +432,7 @@ impl Criterion for Binomial {
 /// The Normal regression family.
 ///
 /// This is equivalent to the Linear Regression model.
+#[derive(Debug)]
 pub struct Normal;
 
 impl Criterion for Normal {
@@ -437,6 +444,7 @@ impl Criterion for Normal {
 }
 
 /// The Poisson regression family.
+#[derive(Debug)]
 pub struct Poisson;
 
 impl Criterion for Poisson {

--- a/rusty-machine/src/learning/glm.rs
+++ b/rusty-machine/src/learning/glm.rs
@@ -221,7 +221,7 @@ pub trait LinkFunc {
 /// The Logit link function.
 ///
 /// Used primarily as the canonical link in Binomial Regression.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Logit;
 
 /// The Logit link function.
@@ -245,7 +245,7 @@ impl LinkFunc for Logit {
 /// The log link function.
 ///
 /// Used primarily as the canonical link in Poisson Regression.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Log;
 
 /// The log link function.
@@ -268,7 +268,7 @@ impl LinkFunc for Log {
 /// The Identity link function.
 ///
 /// Used primarily as the canonical link in Linear Regression.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Identity;
 
 /// The Identity link function.
@@ -291,7 +291,7 @@ impl LinkFunc for Identity {
 /// The Bernoulli regression family.
 ///
 /// This is equivalent to logistic regression.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Bernoulli;
 
 impl Criterion for Bernoulli {
@@ -432,7 +432,7 @@ impl Criterion for Binomial {
 /// The Normal regression family.
 ///
 /// This is equivalent to the Linear Regression model.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Normal;
 
 impl Criterion for Normal {
@@ -444,7 +444,7 @@ impl Criterion for Normal {
 }
 
 /// The Poisson regression family.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Poisson;
 
 impl Criterion for Poisson {

--- a/rusty-machine/src/learning/gmm.rs
+++ b/rusty-machine/src/learning/gmm.rs
@@ -37,7 +37,7 @@ use learning::toolkit::rand_utils;
 /// - Full : The full covariance structure.
 /// - Regularized : Adds a regularization constant to the covariance diagonal.
 /// - Diagonal : Only the diagonal covariance structure.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum CovOption {
     /// The full covariance structure.
     Full,

--- a/rusty-machine/src/learning/gmm.rs
+++ b/rusty-machine/src/learning/gmm.rs
@@ -37,6 +37,7 @@ use learning::toolkit::rand_utils;
 /// - Full : The full covariance structure.
 /// - Regularized : Adds a regularization constant to the covariance diagonal.
 /// - Diagonal : Only the diagonal covariance structure.
+#[derive(Debug)]
 pub enum CovOption {
     /// The full covariance structure.
     Full,
@@ -48,6 +49,7 @@ pub enum CovOption {
 
 
 /// A Gaussian Mixture Model
+#[derive(Debug)]
 pub struct GaussianMixtureModel {
     comp_count: usize,
     mix_weights: Vector<f64>,

--- a/rusty-machine/src/learning/gp.rs
+++ b/rusty-machine/src/learning/gp.rs
@@ -38,6 +38,7 @@ pub trait MeanFunc {
 }
 
 /// Constant mean function
+#[derive(Debug)]
 pub struct ConstMean {
     a: f64,
 }
@@ -60,6 +61,7 @@ impl MeanFunc for ConstMean {
 /// Gaussian process with generic kernel and deterministic mean function.
 /// Can be used for gaussian process regression with noise.
 /// Currently does not support classification.
+#[derive(Debug)]
 pub struct GaussianProcess<T: Kernel, U: MeanFunc> {
     ker: T,
     mean: U,
@@ -81,7 +83,7 @@ pub struct GaussianProcess<T: Kernel, U: MeanFunc> {
 /// Note that zero noise can often lead to numerical instability.
 /// A small value for the noise may be a better alternative.
 impl Default for GaussianProcess<SquaredExp, ConstMean> {
-    
+
     fn default() -> GaussianProcess<SquaredExp, ConstMean> {
         GaussianProcess {
             ker: SquaredExp::default(),

--- a/rusty-machine/src/learning/gp.rs
+++ b/rusty-machine/src/learning/gp.rs
@@ -38,7 +38,7 @@ pub trait MeanFunc {
 }
 
 /// Constant mean function
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct ConstMean {
     a: f64,
 }

--- a/rusty-machine/src/learning/k_means.rs
+++ b/rusty-machine/src/learning/k_means.rs
@@ -50,7 +50,7 @@ use rand::{Rng, thread_rng};
 use libnum::abs;
 
 /// Initialization Algorithm enum.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub enum InitAlgorithm {
     /// The Forgy initialization scheme.
     Forgy,

--- a/rusty-machine/src/learning/k_means.rs
+++ b/rusty-machine/src/learning/k_means.rs
@@ -50,6 +50,7 @@ use rand::{Rng, thread_rng};
 use libnum::abs;
 
 /// Initialization Algorithm enum.
+#[derive(Debug)]
 pub enum InitAlgorithm {
     /// The Forgy initialization scheme.
     Forgy,
@@ -63,6 +64,7 @@ pub enum InitAlgorithm {
 ///
 /// Contains option for centroids.
 /// Specifies iterations and number of classes.
+#[derive(Debug)]
 pub struct KMeansClassifier {
     /// Max iterations of algorithm to run.
     pub iters: usize,

--- a/rusty-machine/src/learning/lin_reg.rs
+++ b/rusty-machine/src/learning/lin_reg.rs
@@ -18,7 +18,7 @@
 //! let targets = Vector::new(vec![1.,5.,9.,13.]);
 //!
 //! let mut lin_mod = LinRegressor::default();
-//! 
+//!
 //! // Train the model
 //! lin_mod.train(&inputs, &targets);
 //!
@@ -42,6 +42,7 @@ use learning::optim::Optimizable;
 /// Linear Regression Model.
 ///
 /// Contains option for optimized parameter.
+#[derive(Debug)]
 pub struct LinRegressor {
     /// The parameters for the regression model.
     parameters: Option<Vector<f64>>,
@@ -114,7 +115,7 @@ impl Optimizable for LinRegressor {
     type Targets = Vector<f64>;
 
     fn compute_grad(&self, params: &[f64], inputs: &Matrix<f64>, targets: &Vector<f64>) -> (f64, Vec<f64>) {
-        
+
         let beta_vec = Vector::new(params.to_vec());
         let outputs = inputs * beta_vec;
 
@@ -141,7 +142,7 @@ impl LinRegressor {
     /// let targets = Vector::new(vec![1.,5.,9.,13.]);
     ///
     /// let mut lin_mod = LinRegressor::default();
-    /// 
+    ///
     /// // Train the model
     /// lin_mod.train_with_optimization(&inputs, &targets);
     ///

--- a/rusty-machine/src/learning/logistic_reg.rs
+++ b/rusty-machine/src/learning/logistic_reg.rs
@@ -45,6 +45,7 @@ use learning::optim::{OptimAlgorithm, Optimizable};
 /// Logistic Regression Model.
 ///
 /// Contains option for optimized parameter.
+#[derive(Debug)]
 pub struct LogisticRegressor<A>
     where A: OptimAlgorithm<BaseLogisticRegressor>
 {
@@ -139,6 +140,7 @@ impl<A : OptimAlgorithm<BaseLogisticRegressor>> SupModel<Matrix<f64>, Vector<f64
 /// The Base Logistic Regression model.
 ///
 /// This struct cannot be instantianated and is used internally only.
+#[derive(Debug)]
 pub struct BaseLogisticRegressor {
     parameters: Option<Vector<f64>>,
 }

--- a/rusty-machine/src/learning/nnet.rs
+++ b/rusty-machine/src/learning/nnet.rs
@@ -426,7 +426,7 @@ pub trait Criterion {
 ///
 /// Uses the Sigmoid activation function and the
 /// cross entropy error.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct BCECriterion;
 
 impl Criterion for BCECriterion {
@@ -438,7 +438,7 @@ impl Criterion for BCECriterion {
 ///
 /// Uses the Linear activation function and the
 /// mean squared error.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct MSECriterion;
 
 impl Criterion for MSECriterion {

--- a/rusty-machine/src/learning/nnet.rs
+++ b/rusty-machine/src/learning/nnet.rs
@@ -45,6 +45,7 @@ use rand::{Rng, thread_rng};
 ///
 /// The Neural Network struct specifies a Criterion and
 /// a gradient descent algorithm.
+#[derive(Debug)]
 pub struct NeuralNet<'a, T, A>
     where T: Criterion,
           A: OptimAlgorithm<BaseNeuralNet<'a, T>>
@@ -152,6 +153,7 @@ impl<'a, T, A> NeuralNet<'a, T, A>
 /// Base Neural Network struct
 ///
 /// This struct cannot be instantianated and is used internally only.
+#[derive(Debug)]
 pub struct BaseNeuralNet<'a, T: Criterion> {
     layer_sizes: &'a [usize],
     weights: Vec<f64>,
@@ -424,6 +426,7 @@ pub trait Criterion {
 ///
 /// Uses the Sigmoid activation function and the
 /// cross entropy error.
+#[derive(Debug)]
 pub struct BCECriterion;
 
 impl Criterion for BCECriterion {
@@ -435,6 +438,7 @@ impl Criterion for BCECriterion {
 ///
 /// Uses the Linear activation function and the
 /// mean squared error.
+#[derive(Debug)]
 pub struct MSECriterion;
 
 impl Criterion for MSECriterion {

--- a/rusty-machine/src/learning/optim/fmincg.rs
+++ b/rusty-machine/src/learning/optim/fmincg.rs
@@ -36,7 +36,7 @@ use std::f64;
 
 
 /// Conjugate Gradient Descent algorithm
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct ConjugateGD {
     /// Constant in the Wolfe-Powell conditions.
     pub rho: f64,

--- a/rusty-machine/src/learning/optim/fmincg.rs
+++ b/rusty-machine/src/learning/optim/fmincg.rs
@@ -36,6 +36,7 @@ use std::f64;
 
 
 /// Conjugate Gradient Descent algorithm
+#[derive(Debug)]
 pub struct ConjugateGD {
     /// Constant in the Wolfe-Powell conditions.
     pub rho: f64,
@@ -55,7 +56,7 @@ pub struct ConjugateGD {
 }
 
 /// The default Conjugate GD algorithm.
-/// 
+///
 /// The defaults are:
 ///
 /// - rho = 0.01

--- a/rusty-machine/src/learning/optim/grad_desc.rs
+++ b/rusty-machine/src/learning/optim/grad_desc.rs
@@ -13,7 +13,7 @@ use linalg::vector::Vector;
 use linalg::matrix::Matrix;
 
 /// Batch Gradient Descent algorithm
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct GradientDesc {
     /// The step-size for the gradient descent steps.
     pub alpha: f64,
@@ -82,7 +82,7 @@ impl<M: Optimizable> OptimAlgorithm<M> for GradientDesc {
 /// Stochastic Gradient Descent algorithm.
 ///
 /// Uses basic momentum to control the learning rate.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct StochasticGD {
     /// Controls the momentum of the descent
     pub alpha: f64,

--- a/rusty-machine/src/learning/optim/grad_desc.rs
+++ b/rusty-machine/src/learning/optim/grad_desc.rs
@@ -13,6 +13,7 @@ use linalg::vector::Vector;
 use linalg::matrix::Matrix;
 
 /// Batch Gradient Descent algorithm
+#[derive(Debug)]
 pub struct GradientDesc {
     /// The step-size for the gradient descent steps.
     pub alpha: f64,
@@ -27,7 +28,7 @@ pub struct GradientDesc {
 /// - alpha = 0.3
 /// - iters = 100
 impl Default for GradientDesc {
-    
+
     fn default() -> GradientDesc {
         GradientDesc {
             alpha: 0.3,
@@ -81,6 +82,7 @@ impl<M: Optimizable> OptimAlgorithm<M> for GradientDesc {
 /// Stochastic Gradient Descent algorithm.
 ///
 /// Uses basic momentum to control the learning rate.
+#[derive(Debug)]
 pub struct StochasticGD {
     /// Controls the momentum of the descent
     pub alpha: f64,
@@ -98,7 +100,7 @@ pub struct StochasticGD {
 /// - mu = 0.1
 /// - iters = 20
 impl Default for StochasticGD {
-    
+
     fn default() -> StochasticGD {
         StochasticGD {
             alpha: 0.1,

--- a/rusty-machine/src/learning/svm.rs
+++ b/rusty-machine/src/learning/svm.rs
@@ -23,7 +23,7 @@
 //!
 //! // Train the model
 //! svm_mod.train(&inputs, &targets);
-//! 
+//!
 //! // Now we'll predict a new point
 //! let new_point = Matrix::new(1,1,vec![10.]);
 //! let output = svm_mod.predict(&new_point);
@@ -43,6 +43,7 @@ use rand;
 use rand::Rng;
 
 /// Support Vector Machine
+#[derive(Debug)]
 pub struct SVM<K: Kernel> {
     ker: K,
     alpha: Option<Vector<f64>>,

--- a/rusty-machine/src/learning/toolkit/activ_fn.rs
+++ b/rusty-machine/src/learning/toolkit/activ_fn.rs
@@ -21,7 +21,7 @@ pub trait ActivationFunc {
 }
 
 /// Sigmoid activation function.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Sigmoid;
 
 impl ActivationFunc for Sigmoid {
@@ -45,7 +45,7 @@ impl ActivationFunc for Sigmoid {
 }
 
 /// Linear activation function.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Linear;
 
 impl ActivationFunc for Linear {
@@ -63,7 +63,7 @@ impl ActivationFunc for Linear {
 }
 
 /// Exponential activation function.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Exp;
 
 impl ActivationFunc for Exp {

--- a/rusty-machine/src/learning/toolkit/activ_fn.rs
+++ b/rusty-machine/src/learning/toolkit/activ_fn.rs
@@ -21,6 +21,7 @@ pub trait ActivationFunc {
 }
 
 /// Sigmoid activation function.
+#[derive(Debug)]
 pub struct Sigmoid;
 
 impl ActivationFunc for Sigmoid {
@@ -44,6 +45,7 @@ impl ActivationFunc for Sigmoid {
 }
 
 /// Linear activation function.
+#[derive(Debug)]
 pub struct Linear;
 
 impl ActivationFunc for Linear {
@@ -61,6 +63,7 @@ impl ActivationFunc for Linear {
 }
 
 /// Exponential activation function.
+#[derive(Debug)]
 pub struct Exp;
 
 impl ActivationFunc for Exp {

--- a/rusty-machine/src/learning/toolkit/cost_fn.rs
+++ b/rusty-machine/src/learning/toolkit/cost_fn.rs
@@ -21,6 +21,7 @@ pub trait CostFunc<T> {
 }
 
 /// The mean squared error cost function.
+#[derive(Debug)]
 pub struct MeanSqError;
 
 // For generics we need a trait for "Hadamard product" here
@@ -56,6 +57,7 @@ impl CostFunc<Vector<f64>> for MeanSqError {
 }
 
 /// The cross entropy error cost function.
+#[derive(Debug)]
 pub struct CrossEntropyError;
 
 impl CostFunc<Matrix<f64>> for CrossEntropyError {

--- a/rusty-machine/src/learning/toolkit/cost_fn.rs
+++ b/rusty-machine/src/learning/toolkit/cost_fn.rs
@@ -21,7 +21,7 @@ pub trait CostFunc<T> {
 }
 
 /// The mean squared error cost function.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct MeanSqError;
 
 // For generics we need a trait for "Hadamard product" here
@@ -57,7 +57,7 @@ impl CostFunc<Vector<f64>> for MeanSqError {
 }
 
 /// The cross entropy error cost function.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct CrossEntropyError;
 
 impl CostFunc<Matrix<f64>> for CrossEntropyError {

--- a/rusty-machine/src/learning/toolkit/kernel.rs
+++ b/rusty-machine/src/learning/toolkit/kernel.rs
@@ -132,7 +132,7 @@ impl<T: Kernel, U: Kernel> Mul<KernelArith<T>> for KernelArith<U> {
 /// The Linear Kernel
 ///
 /// k(x,y) = x<sup>T</sup>y + c
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Linear {
     /// Constant term added to inner product.
     pub c: f64,
@@ -176,7 +176,7 @@ impl Kernel for Linear {
 /// The Polynomial Kernel
 ///
 /// k(x,y) = (αx<sup>T</sup>y + c)<sup>d</sup>
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Polynomial {
     /// Scaling of the inner product.
     pub alpha: f64,
@@ -239,7 +239,7 @@ impl Kernel for Polynomial {
 /// k(x,y) = A _exp_(-||x-y||<sup>2</sup> / 2l<sup>2</sup>)
 ///
 /// Where A is the amplitude and l the length scale.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct SquaredExp {
     /// The length scale of the kernel.
     pub ls: f64,
@@ -301,7 +301,7 @@ impl Kernel for SquaredExp {
 /// k(x,y) = A _exp_(-||x-y|| / 2l<sup>2</sup>)
 ///
 /// Where A is the amplitude and l is the length scale.
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Exponential {
     /// The length scale of the kernel.
     pub ls: f64,
@@ -361,7 +361,7 @@ impl Kernel for Exponential {
 /// The Hyperbolic Tangent Kernel.
 ///
 /// ker(x,y) = _tanh_(αx<sup>T</sup>y + c)
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct HyperTan {
     /// The scaling of the inner product.
     pub alpha: f64,
@@ -415,7 +415,7 @@ impl Kernel for HyperTan {
 /// The Multiquadric Kernel.
 ///
 /// k(x,y) = _sqrt_(||x-y||<sup>2</sup> + c<sup>2</sup>)
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct Multiquadric {
     /// Constant added to square of difference.
     pub c: f64,
@@ -464,7 +464,7 @@ impl Kernel for Multiquadric {
 /// The Rational Quadratic Kernel.
 ///
 /// k(x,y) = (1 + ||x-y||<sup>2</sup> / (2αl<sup>2</sup>))<sup>-α</sup>
-#[derive(Debug)]
+#[derive(Clone, Copy, Debug)]
 pub struct RationalQuadratic {
     /// Controls inverse power and difference scale.
     pub alpha: f64,

--- a/rusty-machine/src/learning/toolkit/kernel.rs
+++ b/rusty-machine/src/learning/toolkit/kernel.rs
@@ -43,6 +43,7 @@ pub trait Kernel {
 /// println!("{0}", poly_plus_hypert_ker.kernel(&[1f64,2f64,3f64],
 ///                                             &[3f64,1f64,2f64]));
 /// ```
+#[derive(Debug)]
 pub struct KernelSum<T, U>
     where T: Kernel,
           U: Kernel
@@ -83,6 +84,7 @@ impl<T, U> Kernel for KernelSum<T, U>
 /// println!("{0}", poly_plus_hypert_ker.kernel(&[1f64,2f64,3f64],
 ///                                             &[3f64,1f64,2f64]));
 /// ```
+#[derive(Debug)]
 pub struct KernelProd<T, U>
     where T: Kernel,
           U: Kernel
@@ -102,6 +104,7 @@ impl<T, U> Kernel for KernelProd<T, U>
 }
 
 /// A wrapper tuple struct used for kernel arithmetic
+#[derive(Debug)]
 pub struct KernelArith<K: Kernel>(pub K);
 
 impl<T: Kernel, U: Kernel> Add<KernelArith<T>> for KernelArith<U> {
@@ -129,6 +132,7 @@ impl<T: Kernel, U: Kernel> Mul<KernelArith<T>> for KernelArith<U> {
 /// The Linear Kernel
 ///
 /// k(x,y) = x<sup>T</sup>y + c
+#[derive(Debug)]
 pub struct Linear {
     /// Constant term added to inner product.
     pub c: f64,
@@ -155,7 +159,7 @@ impl Linear {
 /// Constructs the default Linear Kernel
 ///
 /// The defaults are:
-/// 
+///
 /// - c = 0
 impl Default for Linear {
     fn default() -> Linear {
@@ -172,6 +176,7 @@ impl Kernel for Linear {
 /// The Polynomial Kernel
 ///
 /// k(x,y) = (αx<sup>T</sup>y + c)<sup>d</sup>
+#[derive(Debug)]
 pub struct Polynomial {
     /// Scaling of the inner product.
     pub alpha: f64,
@@ -234,6 +239,7 @@ impl Kernel for Polynomial {
 /// k(x,y) = A _exp_(-||x-y||<sup>2</sup> / 2l<sup>2</sup>)
 ///
 /// Where A is the amplitude and l the length scale.
+#[derive(Debug)]
 pub struct SquaredExp {
     /// The length scale of the kernel.
     pub ls: f64,
@@ -295,6 +301,7 @@ impl Kernel for SquaredExp {
 /// k(x,y) = A _exp_(-||x-y|| / 2l<sup>2</sup>)
 ///
 /// Where A is the amplitude and l is the length scale.
+#[derive(Debug)]
 pub struct Exponential {
     /// The length scale of the kernel.
     pub ls: f64,
@@ -310,7 +317,7 @@ impl Exponential {
     /// ```
     /// use rusty_machine::learning::toolkit::kernel;
     /// use rusty_machine::learning::toolkit::kernel::Kernel;
-    /// 
+    ///
     /// // Construct a kernel with lengthscale 2 and amplitude 1.
     /// let ker = kernel::Exponential::new(2f64, 1f64);
     ///
@@ -354,6 +361,7 @@ impl Kernel for Exponential {
 /// The Hyperbolic Tangent Kernel.
 ///
 /// ker(x,y) = _tanh_(αx<sup>T</sup>y + c)
+#[derive(Debug)]
 pub struct HyperTan {
     /// The scaling of the inner product.
     pub alpha: f64,
@@ -407,6 +415,7 @@ impl Kernel for HyperTan {
 /// The Multiquadric Kernel.
 ///
 /// k(x,y) = _sqrt_(||x-y||<sup>2</sup> + c<sup>2</sup>)
+#[derive(Debug)]
 pub struct Multiquadric {
     /// Constant added to square of difference.
     pub c: f64,
@@ -455,6 +464,7 @@ impl Kernel for Multiquadric {
 /// The Rational Quadratic Kernel.
 ///
 /// k(x,y) = (1 + ||x-y||<sup>2</sup> / (2αl<sup>2</sup>))<sup>-α</sup>
+#[derive(Debug)]
 pub struct RationalQuadratic {
     /// Controls inverse power and difference scale.
     pub alpha: f64,

--- a/rusty-machine/src/lib.rs
+++ b/rusty-machine/src/lib.rs
@@ -81,6 +81,7 @@
 //! `let mut gp = GaussianProcess::default();`. Conversely, you could also implement
 //! your own kernels and mean functions by using the appropriate traits.
 
+#![warn(missing_debug_implementations)]
 
 extern crate num as libnum;
 extern crate rand;


### PR DESCRIPTION
Herein:

* remaining `derive(Debug)` attributes, a sequel to #18  
* activating the missing-`Debug` lint at `warn` level
* `derive(Copy, Clone)` attributes where applicable ("[Generally speaking,](https://doc.rust-lang.org/std/marker/trait.Copy.html#when-should-my-type-be-copy) if your type can implement Copy, it should.")