### PR TITLE
Mutable mat data

### DIFF
--- a/rusty-machine/src/learning/gmm.rs
+++ b/rusty-machine/src/learning/gmm.rs
@@ -207,7 +207,7 @@ impl GaussianMixtureModel {
 
         let mut new_means = membership_weights.transpose() * inputs;
 
-        for (idx, mean) in new_means.iter_mut_rows().enumerate() {
+        for (idx, mean) in new_means.mut_data().chunks_mut(d).enumerate() {
             for m in mean {
                 *m = *m / sum_weights[idx];
             }

--- a/rusty-machine/src/learning/gmm.rs
+++ b/rusty-machine/src/learning/gmm.rs
@@ -207,7 +207,7 @@ impl GaussianMixtureModel {
 
         let mut new_means = membership_weights.transpose() * inputs;
 
-        for (idx, mean) in new_means.mut_data().chunks_mut(d).enumerate() {
+        for (idx, mean) in new_means.iter_mut_rows().enumerate() {
             for m in mean {
                 *m = *m / sum_weights[idx];
             }

--- a/rusty-machine/src/linalg/matrix/mod.rs
+++ b/rusty-machine/src/linalg/matrix/mod.rs
@@ -4,7 +4,6 @@
 //! relating to the matrix linear algebra struct.
 
 use std::fmt;
-use std::slice::ChunksMut;
 use std::ops::{Mul, Add, Div, Sub, Index, Neg};
 use libnum::{One, Zero, Float, FromPrimitive};
 use std::cmp::{PartialEq, min};
@@ -70,8 +69,8 @@ impl<T> Matrix<T> {
     }
 
     /// Returns an iterator over the mutable rows.
-    pub fn iter_mut_rows(&mut self) -> ChunksMut<T> {
-        self.data.chunks_mut(self.cols)
+    pub fn mut_data(&mut self) -> &mut [T] {
+        &mut self.data
     }
 
     /// Consumes the Matrix and returns the Vec of data.

--- a/rusty-machine/src/linalg/matrix/mod.rs
+++ b/rusty-machine/src/linalg/matrix/mod.rs
@@ -4,6 +4,7 @@
 //! relating to the matrix linear algebra struct.
 
 use std::fmt;
+use std::slice::ChunksMut;
 use std::ops::{Mul, Add, Div, Sub, Index, Neg};
 use libnum::{One, Zero, Float, FromPrimitive};
 use std::cmp::{PartialEq, min};
@@ -68,9 +69,9 @@ impl<T> Matrix<T> {
         &self.data
     }
 
-    /// Returns a mutable reference to the underlying data.
-    pub fn mut_data(&mut self) -> &mut Vec<T> {
-        &mut self.data
+    /// Returns an iterator over the mutable rows.
+    pub fn iter_mut_rows(&mut self) -> ChunksMut<T> {
+        self.data.chunks_mut(self.cols)
     }
 
     /// Consumes the Matrix and returns the Vec of data.

--- a/rusty-machine/src/linalg/matrix/mod.rs
+++ b/rusty-machine/src/linalg/matrix/mod.rs
@@ -68,7 +68,7 @@ impl<T> Matrix<T> {
         &self.data
     }
 
-    /// Returns an iterator over the mutable rows.
+    /// Returns a mutable slice of the underlying data.
     pub fn mut_data(&mut self) -> &mut [T] {
         &mut self.data
     }


### PR DESCRIPTION
Modified `mut_data` method for matrices to return a mutable slice instead of a vector.

This PR will solve issue #24 