### PR TITLE
Memory alloc

### DIFF
--- a/rusty-machine/benches/linalg/matrix.rs
+++ b/rusty-machine/benches/linalg/matrix.rs
@@ -7,27 +7,39 @@ fn empty(b: &mut Bencher) {
 }
 
 #[bench]
-fn mat_add(b: &mut Bencher) {
+fn mat_ref_add_100_100(b: &mut Bencher) {
 
-    let a = Matrix::new(10, 10, vec![2.0;100]);
-    let c = Matrix::new(10, 10, vec![3.0;100]);
+    let a = Matrix::new(100, 100, vec![2.0;10000]);
+    let c = Matrix::new(100, 100, vec![3.0;10000]);
 
-    b.iter(|| &a + &c)
+    b.iter(|| {
+    	&a + &c
+    })
 }
 
 #[bench]
-fn mat_mul(b: &mut Bencher) {
+fn mat_create_add_100_100(b: &mut Bencher) {
+    let c = Matrix::new(100, 100, vec![3.0;10000]);
+
+    b.iter(|| {
+    	let a = Matrix::new(100, 100, vec![2.0;10000]);
+    	a + &c
+    })
+}
+
+#[bench]
+fn mat_create_100_100(b: &mut Bencher) {
+    b.iter(|| {
+    	let a = Matrix::new(100, 100, vec![2.0;10000]);
+    	a
+    })
+}
+
+#[bench]
+fn mat_mul_10_10(b: &mut Bencher) {
 
     let a = Matrix::new(10, 10, vec![2.0;100]);
     let c = Matrix::new(10, 10, vec![3.0;100]);
 
     b.iter(|| &a * &c)
-}
-
-#[bench]
-fn mat_det(b: &mut Bencher) {
-
-    let a = Matrix::new(10, 10, vec![2.0;100]);
-
-    b.iter(|| a.det());
 }

--- a/rusty-machine/src/linalg/matrix/mod.rs
+++ b/rusty-machine/src/linalg/matrix/mod.rs
@@ -363,14 +363,12 @@ impl<T: Copy> Matrix<T> {
     ///
     /// assert_eq!(*b.data(), vec![2.0; 4]);
     /// ```
-    pub fn apply(self, f: &Fn(T) -> T) -> Matrix<T> {
-        let new_data = self.data.into_iter().map(f).collect();
-
-        Matrix {
-            rows: self.rows,
-            cols: self.cols,
-            data: new_data,
+    pub fn apply(mut self, f: &Fn(T) -> T) -> Matrix<T> {
+        for val in self.data.iter_mut() {
+            *val = f(*val);
         }
+
+        self
     }
 }
 
@@ -1251,8 +1249,8 @@ impl<'a, 'b, T: Copy + One + Zero + Sub<T, Output = T>> Sub<&'b T> for &'a Matri
 impl<T: Copy + One + Zero + Sub<T, Output = T>> Sub<Matrix<T>> for Matrix<T> {
     type Output = Matrix<T>;
 
-    fn sub(self, f: Matrix<T>) -> Matrix<T> {
-        self - &f
+    fn sub(self, m: Matrix<T>) -> Matrix<T> {
+        self - &m
     }
 }
 
@@ -1260,8 +1258,10 @@ impl<T: Copy + One + Zero + Sub<T, Output = T>> Sub<Matrix<T>> for Matrix<T> {
 impl<'a, T: Copy + One + Zero + Sub<T, Output = T>> Sub<Matrix<T>> for &'a Matrix<T> {
     type Output = Matrix<T>;
 
-    fn sub(self, f: Matrix<T>) -> Matrix<T> {
-        f - self
+    fn sub(self, mut m: Matrix<T>) -> Matrix<T> {
+        utils::in_place_vec_bin_op(&mut m.data, &self.data, |x,&y| {*x = y - *x});
+        
+        m
     }
 }
 
@@ -1269,8 +1269,9 @@ impl<'a, T: Copy + One + Zero + Sub<T, Output = T>> Sub<Matrix<T>> for &'a Matri
 impl<'a, T: Copy + One + Zero + Sub<T, Output = T>> Sub<&'a Matrix<T>> for Matrix<T> {
     type Output = Matrix<T>;
 
-    fn sub(mut self, f: &Matrix<T>) -> Matrix<T> {
-        utils::in_place_vec_bin_op(&mut self.data, &f.data, |x,&y| {*x = *x - y});
+    fn sub(mut self, m: &Matrix<T>) -> Matrix<T> {
+        utils::in_place_vec_bin_op(&mut self.data, &m.data, |x,&y| {*x = *x - y});
+        
         self
     }
 }

--- a/rusty-machine/src/linalg/matrix/mod.rs
+++ b/rusty-machine/src/linalg/matrix/mod.rs
@@ -967,7 +967,7 @@ impl<T: Copy + One + Zero + Mul<T, Output = T>> Mul<T> for Matrix<T> {
     type Output = Matrix<T>;
 
     fn mul(self, f: T) -> Matrix<T> {
-        (&self) * (&f)
+        self * &f
     }
 }
 
@@ -975,8 +975,12 @@ impl<T: Copy + One + Zero + Mul<T, Output = T>> Mul<T> for Matrix<T> {
 impl<'a, T: Copy + One + Zero + Mul<T, Output = T>> Mul<&'a T> for Matrix<T> {
     type Output = Matrix<T>;
 
-    fn mul(self, f: &T) -> Matrix<T> {
-        (&self) * f
+    fn mul(mut self, f: &T) -> Matrix<T> {
+        for val in self.data.iter_mut() {
+            *val = *val * *f;
+        }
+
+        self
     }
 }
 
@@ -1111,7 +1115,7 @@ impl<T: Copy + One + Zero + Add<T, Output = T>> Add<T> for Matrix<T> {
     type Output = Matrix<T>;
 
     fn add(self, f: T) -> Matrix<T> {
-        (&self) + (&f)
+        self + &f
     }
 }
 
@@ -1128,8 +1132,12 @@ impl<'a, T: Copy + One + Zero + Add<T, Output = T>> Add<T> for &'a Matrix<T> {
 impl<'a, T: Copy + One + Zero + Add<T, Output = T>> Add<&'a T> for Matrix<T> {
     type Output = Matrix<T>;
 
-    fn add(self, f: &T) -> Matrix<T> {
-        (&self) + f
+    fn add(mut self, f: &T) -> Matrix<T> {
+        for val in self.data.iter_mut() {
+            *val = *val + *f;
+        }
+
+        self
     }
 }
 
@@ -1152,7 +1160,7 @@ impl<T: Copy + One + Zero + Add<T, Output = T>> Add<Matrix<T>> for Matrix<T> {
     type Output = Matrix<T>;
 
     fn add(self, f: Matrix<T>) -> Matrix<T> {
-        (&self) + (&f)
+        self + &f
     }
 }
 
@@ -1161,7 +1169,7 @@ impl<'a, T: Copy + One + Zero + Add<T, Output = T>> Add<Matrix<T>> for &'a Matri
     type Output = Matrix<T>;
 
     fn add(self, f: Matrix<T>) -> Matrix<T> {
-        self + (&f)
+        f + self
     }
 }
 
@@ -1169,8 +1177,9 @@ impl<'a, T: Copy + One + Zero + Add<T, Output = T>> Add<Matrix<T>> for &'a Matri
 impl<'a, T: Copy + One + Zero + Add<T, Output = T>> Add<&'a Matrix<T>> for Matrix<T> {
     type Output = Matrix<T>;
 
-    fn add(self, f: &Matrix<T>) -> Matrix<T> {
-        (&self) + f
+    fn add(mut self, f: &Matrix<T>) -> Matrix<T> {
+        utils::in_place_vec_bin_op(&mut self.data, &f.data, |x,&y| {*x = *x + y});
+        self
     }
 }
 
@@ -1197,7 +1206,7 @@ impl<T: Copy + One + Zero + Sub<T, Output = T>> Sub<T> for Matrix<T> {
     type Output = Matrix<T>;
 
     fn sub(self, f: T) -> Matrix<T> {
-        (&self) - (&f)
+        self - (&f)
     }
 }
 
@@ -1205,8 +1214,12 @@ impl<T: Copy + One + Zero + Sub<T, Output = T>> Sub<T> for Matrix<T> {
 impl<'a, T: Copy + One + Zero + Sub<T, Output = T>> Sub<&'a T> for Matrix<T> {
     type Output = Matrix<T>;
 
-    fn sub(self, f: &T) -> Matrix<T> {
-        (&self) - f
+    fn sub(mut self, f: &T) -> Matrix<T> {
+        for val in self.data.iter_mut() {
+            *val = *val - *f;
+        }
+
+        self
     }
 }
 
@@ -1239,7 +1252,7 @@ impl<T: Copy + One + Zero + Sub<T, Output = T>> Sub<Matrix<T>> for Matrix<T> {
     type Output = Matrix<T>;
 
     fn sub(self, f: Matrix<T>) -> Matrix<T> {
-        (&self) - (&f)
+        self - &f
     }
 }
 
@@ -1248,7 +1261,7 @@ impl<'a, T: Copy + One + Zero + Sub<T, Output = T>> Sub<Matrix<T>> for &'a Matri
     type Output = Matrix<T>;
 
     fn sub(self, f: Matrix<T>) -> Matrix<T> {
-        self - (&f)
+        f - self
     }
 }
 
@@ -1256,8 +1269,9 @@ impl<'a, T: Copy + One + Zero + Sub<T, Output = T>> Sub<Matrix<T>> for &'a Matri
 impl<'a, T: Copy + One + Zero + Sub<T, Output = T>> Sub<&'a Matrix<T>> for Matrix<T> {
     type Output = Matrix<T>;
 
-    fn sub(self, f: &Matrix<T>) -> Matrix<T> {
-        (&self) - f
+    fn sub(mut self, f: &Matrix<T>) -> Matrix<T> {
+        utils::in_place_vec_bin_op(&mut self.data, &f.data, |x,&y| {*x = *x - y});
+        self
     }
 }
 
@@ -1284,7 +1298,7 @@ impl<T: Copy + One + Zero + PartialEq + Div<T, Output = T>> Div<T> for Matrix<T>
     type Output = Matrix<T>;
 
     fn div(self, f: T) -> Matrix<T> {
-        (&self) / (&f)
+        self / (&f)
     }
 }
 
@@ -1301,8 +1315,12 @@ impl<'a, T: Copy + One + Zero + PartialEq + Div<T, Output = T>> Div<T> for &'a M
 impl<'a, T: Copy + One + Zero + PartialEq + Div<T, Output = T>> Div<&'a T> for Matrix<T> {
     type Output = Matrix<T>;
 
-    fn div(self, f: &T) -> Matrix<T> {
-        (&self) / f
+    fn div(mut self, f: &T) -> Matrix<T> {
+        for val in self.data.iter_mut() {
+            *val = *val / *f;
+        }
+
+        self
     }
 }
 
@@ -1327,14 +1345,12 @@ impl<'a, 'b, T: Copy + One + Zero + PartialEq + Div<T, Output = T>> Div<&'b T> f
 impl<T: Neg<Output = T> + Copy> Neg for Matrix<T> {
     type Output = Matrix<T>;
 
-    fn neg(self) -> Matrix<T> {
-        let new_data = self.data.iter().map(|v| -*v).collect();
-
-        Matrix {
-            cols: self.cols,
-            rows: self.rows,
-            data: new_data,
+    fn neg(mut self) -> Matrix<T> {
+        for val in self.data.iter_mut() {
+            *val = -*val;
         }
+
+        self
     }
 }
 

--- a/rusty-machine/src/linalg/utils.rs
+++ b/rusty-machine/src/linalg/utils.rs
@@ -112,8 +112,26 @@ pub fn unrolled_sum<T>(mut xs: &[T]) -> T
     sum
 }
 
+/// Vectorized binary operation applied to two slices.
+/// The first argument should be a mutable slice which will
+/// be modified in place to prevent new memory allocation.
+///
+/// # Examples
+///
+/// ```
+/// use rusty_machine::linalg::utils;
+///
+/// let mut a = vec![2.0; 10];
+/// let b = vec![3.0; 10];
+///
+/// utils::in_place_vec_bin_op(&mut a, &b, |x, &y| { *x = 1f64 + *x * y });
+///
+/// // Will print a vector of `7`s.
+/// println!("{:?}", a);
+/// ```
 pub fn in_place_vec_bin_op<F, T: Copy>(mut u: &mut [T], v: &[T], mut f: F)
     where F: FnMut(&mut T, &T) {
+        debug_assert_eq!(u.len(), v.len());
         let len = cmp::min(u.len(), v.len());
         
         let ys = &v[..len];
@@ -130,6 +148,7 @@ pub fn in_place_vec_bin_op<F, T: Copy>(mut u: &mut [T], v: &[T], mut f: F)
 
 fn vec_bin_op<F, T: Copy>(u: &[T], v: &[T], f: F) -> Vec<T>
     where F: Fn(T, T) -> T {
+        debug_assert_eq!(u.len(), v.len());
         let len = cmp::min(u.len(), v.len());
         
         let xs = &u[..len];

--- a/rusty-machine/src/linalg/utils.rs
+++ b/rusty-machine/src/linalg/utils.rs
@@ -5,7 +5,6 @@
 use std::cmp;
 use libnum::Zero;
 use std::ops::{Add, Mul, Sub, Div};
-use std::mem;
 
 /// Compute dot product of two slices.
 ///
@@ -135,14 +134,10 @@ pub fn in_place_vec_bin_op<F, T: Copy>(mut u: &mut [T], v: &[T], mut f: F)
         let len = cmp::min(u.len(), v.len());
         
         let ys = &v[..len];
-        
-        let mut new_slice = mem::replace(&mut u, &mut []);
-        let (l,_) = new_slice.split_at_mut(len);
-        u = l;
-        
-    
+        let xs = &mut u[..len];
+
         for i in 0..len {
-            f(&mut u[i], &ys[i])
+            f(&mut xs[i], &ys[i])
         }
 }
 

--- a/rusty-machine/src/linalg/vector.rs
+++ b/rusty-machine/src/linalg/vector.rs
@@ -83,13 +83,11 @@ impl<T: Copy> Vector<T> {
     ///
     /// assert_eq!(b.into_vec(), vec![2.0; 4]);
     /// ```
-    pub fn apply(self, f: &Fn(T) -> T) -> Vector<T> {
-        let new_data = self.data.into_iter().map(f).collect();
-
-        Vector {
-            size: self.size,
-            data: new_data,
+    pub fn apply(mut self, f: &Fn(T) -> T) -> Vector<T> {
+        for val in self.data.iter_mut(){
+            *val = f(*val);
         }
+        self
     }
 }
 
@@ -323,7 +321,7 @@ impl<T: Copy + One + Zero + Mul<T, Output = T>> Mul<T> for Vector<T> {
     type Output = Vector<T>;
 
     fn mul(self, f: T) -> Vector<T> {
-        (&self) * (&f)
+        self * &f
     }
 }
 
@@ -340,8 +338,12 @@ impl<'a, T: Copy + One + Zero + Mul<T, Output = T>> Mul<T> for &'a Vector<T> {
 impl<'a, T: Copy + One + Zero + Mul<T, Output = T>> Mul<&'a T> for Vector<T> {
     type Output = Vector<T>;
 
-    fn mul(self, f: &T) -> Vector<T> {
-        (&self) * f
+    fn mul(mut self, f: &T) -> Vector<T> {
+        for val in self.data.iter_mut() {
+            *val = *val * *f;
+        }
+
+        self
     }
 }
 
@@ -364,7 +366,7 @@ impl<T: Copy + One + Zero + PartialEq + Div<T, Output = T>> Div<T> for Vector<T>
     type Output = Vector<T>;
 
     fn div(self, f: T) -> Vector<T> {
-        (&self) / (&f)
+        self / &f
     }
 }
 
@@ -373,7 +375,7 @@ impl<'a, T: Copy + One + Zero + PartialEq + Div<T, Output = T>> Div<T> for &'a V
     type Output = Vector<T>;
 
     fn div(self, f: T) -> Vector<T> {
-        self / (&f)
+        self / &f
     }
 }
 
@@ -381,8 +383,12 @@ impl<'a, T: Copy + One + Zero + PartialEq + Div<T, Output = T>> Div<T> for &'a V
 impl<'a, T: Copy + One + Zero + PartialEq + Div<T, Output = T>> Div<&'a T> for Vector<T> {
     type Output = Vector<T>;
 
-    fn div(self, f: &T) -> Vector<T> {
-        (&self) / f
+    fn div(mut self, f: &T) -> Vector<T> {
+        for val in self.data.iter_mut() {
+            *val = *val / *f;
+        }
+
+        self
     }
 }
 
@@ -406,7 +412,7 @@ impl<T: Copy + One + Zero + Add<T, Output = T>> Add<T> for Vector<T> {
     type Output = Vector<T>;
 
     fn add(self, f: T) -> Vector<T> {
-        (&self) + (&f)
+        self + &f
     }
 }
 
@@ -415,7 +421,7 @@ impl<'a, T: Copy + One + Zero + Add<T, Output = T>> Add<T> for &'a Vector<T> {
     type Output = Vector<T>;
 
     fn add(self, f: T) -> Vector<T> {
-        self + (&f)
+        self + &f
     }
 }
 
@@ -423,8 +429,12 @@ impl<'a, T: Copy + One + Zero + Add<T, Output = T>> Add<T> for &'a Vector<T> {
 impl<'a, T: Copy + One + Zero + Add<T, Output = T>> Add<&'a T> for Vector<T> {
     type Output = Vector<T>;
 
-    fn add(self, f: &T) -> Vector<T> {
-        (&self) + f
+    fn add(mut self, f: &T) -> Vector<T> {
+        for val in self.data.iter_mut() {
+            *val = *val + *f;
+        }
+
+        self
     }
 }
 
@@ -447,7 +457,7 @@ impl<T: Copy + One + Zero + Add<T, Output = T>> Add<Vector<T>> for Vector<T> {
     type Output = Vector<T>;
 
     fn add(self, v: Vector<T>) -> Vector<T> {
-        (&self) + (&v)
+        self + &v
     }
 }
 
@@ -456,7 +466,7 @@ impl<'a, T: Copy + One + Zero + Add<T, Output = T>> Add<Vector<T>> for &'a Vecto
     type Output = Vector<T>;
 
     fn add(self, v: Vector<T>) -> Vector<T> {
-        self + (&v)
+        v + self
     }
 }
 
@@ -464,8 +474,10 @@ impl<'a, T: Copy + One + Zero + Add<T, Output = T>> Add<Vector<T>> for &'a Vecto
 impl<'a, T: Copy + One + Zero + Add<T, Output = T>> Add<&'a Vector<T>> for Vector<T> {
     type Output = Vector<T>;
 
-    fn add(self, v: &Vector<T>) -> Vector<T> {
-        (&self) + v
+    fn add(mut self, v: &Vector<T>) -> Vector<T> {
+        utils::in_place_vec_bin_op(&mut self.data, &v.data, |x, &y| { *x = *x + y});
+
+        self
     }
 }
 
@@ -490,7 +502,7 @@ impl<T: Copy + One + Zero + Sub<T, Output = T>> Sub<T> for Vector<T> {
     type Output = Vector<T>;
 
     fn sub(self, f: T) -> Vector<T> {
-        (&self) - (&f)
+        self - &f
     }
 }
 
@@ -499,7 +511,7 @@ impl<'a, T: Copy + One + Zero + Sub<T, Output = T>> Sub<T> for &'a Vector<T> {
     type Output = Vector<T>;
 
     fn sub(self, f: T) -> Vector<T> {
-        self - (&f)
+        self - &f
     }
 }
 
@@ -507,8 +519,12 @@ impl<'a, T: Copy + One + Zero + Sub<T, Output = T>> Sub<T> for &'a Vector<T> {
 impl<'a, T: Copy + One + Zero + Sub<T, Output = T>> Sub<&'a T> for Vector<T> {
     type Output = Vector<T>;
 
-    fn sub(self, f: &T) -> Vector<T> {
-        (&self) - f
+    fn sub(mut self, f: &T) -> Vector<T> {
+        for val in self.data.iter_mut() {
+            *val = *val - *f;
+        }
+
+        self
     }
 }
 
@@ -531,7 +547,7 @@ impl<T: Copy + One + Zero + Sub<T, Output = T>> Sub<Vector<T>> for Vector<T> {
     type Output = Vector<T>;
 
     fn sub(self, v: Vector<T>) -> Vector<T> {
-        (&self) - (&v)
+        self - &v
     }
 }
 
@@ -539,8 +555,10 @@ impl<T: Copy + One + Zero + Sub<T, Output = T>> Sub<Vector<T>> for Vector<T> {
 impl<'a, T: Copy + One + Zero + Sub<T, Output = T>> Sub<Vector<T>> for &'a Vector<T> {
     type Output = Vector<T>;
 
-    fn sub(self, v: Vector<T>) -> Vector<T> {
-        self - (&v)
+    fn sub(self, mut v: Vector<T>) -> Vector<T> {
+        utils::in_place_vec_bin_op(&mut v.data, &self.data, |x, &y| { *x = y - *x});
+
+        v
     }
 }
 
@@ -548,8 +566,10 @@ impl<'a, T: Copy + One + Zero + Sub<T, Output = T>> Sub<Vector<T>> for &'a Vecto
 impl<'a, T: Copy + One + Zero + Sub<T, Output = T>> Sub<&'a Vector<T>> for Vector<T> {
     type Output = Vector<T>;
 
-    fn sub(self, v: &Vector<T>) -> Vector<T> {
-        (&self) - v
+    fn sub(mut self, v: &Vector<T>) -> Vector<T> {
+        utils::in_place_vec_bin_op(&mut self.data, &v.data, |x, &y| { *x = *x - y});
+
+        self
     }
 }
 
@@ -573,10 +593,12 @@ impl<'a, 'b, T: Copy + One + Zero + Sub<T, Output = T>> Sub<&'b Vector<T>> for &
 impl<T: Neg<Output = T> + Copy> Neg for Vector<T> {
     type Output = Vector<T>;
 
-    fn neg(self) -> Vector<T> {
-        let new_data = self.data.iter().map(|v| -*v).collect();
+    fn neg(mut self) -> Vector<T> {
+        for val in self.data.iter_mut() {
+            *val = -*val;
+        }
 
-        Vector::new(new_data)
+        self
     }
 }
 

--- a/rusty-machine/tests/linalg/mat.rs
+++ b/rusty-machine/tests/linalg/mat.rs
@@ -89,7 +89,8 @@ fn matrix_mul() {
     let a = Matrix::new(3, 2, vec![1., 2., 3., 4., 5., 6.]);
     let b = Matrix::new(2, 3, vec![1., 2., 3., 4., 5., 6.]);
 
-    let c = a * b;
+    // Allocating new memory
+    let c = &a * &b;
 
     assert_eq!(c.rows(), 3);
     assert_eq!(c.cols(), 3);
@@ -123,6 +124,37 @@ fn matrix_vec_mul() {
 fn matrix_f32_mul() {
     let a = Matrix::new(3, 2, vec![1., 2., 3., 4., 5., 6.]);
 
+    // Allocating new memory
+    let c = &a * &2.0;
+
+    assert_eq!(c[[0, 0]], 2.0);
+    assert_eq!(c[[0, 1]], 4.0);
+    assert_eq!(c[[1, 0]], 6.0);
+    assert_eq!(c[[1, 1]], 8.0);
+    assert_eq!(c[[2, 0]], 10.0);
+    assert_eq!(c[[2, 1]], 12.0);
+
+    // Allocating new memory
+    let c = &a * 2.0;
+
+    assert_eq!(c[[0, 0]], 2.0);
+    assert_eq!(c[[0, 1]], 4.0);
+    assert_eq!(c[[1, 0]], 6.0);
+    assert_eq!(c[[1, 1]], 8.0);
+    assert_eq!(c[[2, 0]], 10.0);
+    assert_eq!(c[[2, 1]], 12.0);
+
+    // Reusing memory
+    let c = a.clone() * &2.0;
+
+    assert_eq!(c[[0, 0]], 2.0);
+    assert_eq!(c[[0, 1]], 4.0);
+    assert_eq!(c[[1, 0]], 6.0);
+    assert_eq!(c[[1, 1]], 8.0);
+    assert_eq!(c[[2, 0]], 10.0);
+    assert_eq!(c[[2, 1]], 12.0);
+
+    // Reusing memory
     let c = a * 2.0;
 
     assert_eq!(c[[0, 0]], 2.0);
@@ -138,6 +170,37 @@ fn matrix_add() {
     let a = Matrix::new(3, 2, vec![1., 2., 3., 4., 5., 6.]);
     let b = Matrix::new(3, 2, vec![2., 3., 4., 5., 6., 7.]);
 
+    // Reusing memory
+    let c = &a + &b;
+
+    assert_eq!(c[[0, 0]], 3.0);
+    assert_eq!(c[[0, 1]], 5.0);
+    assert_eq!(c[[1, 0]], 7.0);
+    assert_eq!(c[[1, 1]], 9.0);
+    assert_eq!(c[[2, 0]], 11.0);
+    assert_eq!(c[[2, 1]], 13.0);
+
+    // Allocating new memory
+    let c = a.clone() + &b;
+
+    assert_eq!(c[[0, 0]], 3.0);
+    assert_eq!(c[[0, 1]], 5.0);
+    assert_eq!(c[[1, 0]], 7.0);
+    assert_eq!(c[[1, 1]], 9.0);
+    assert_eq!(c[[2, 0]], 11.0);
+    assert_eq!(c[[2, 1]], 13.0);
+
+    // Allocating new memory
+    let c = &a + b.clone();
+
+    assert_eq!(c[[0, 0]], 3.0);
+    assert_eq!(c[[0, 1]], 5.0);
+    assert_eq!(c[[1, 0]], 7.0);
+    assert_eq!(c[[1, 1]], 9.0);
+    assert_eq!(c[[2, 0]], 11.0);
+    assert_eq!(c[[2, 1]], 13.0);
+
+    // Allocating new memory
     let c = a + b;
 
     assert_eq!(c[[0, 0]], 3.0);
@@ -153,6 +216,37 @@ fn matrix_f32_add() {
     let a = Matrix::new(3, 2, vec![1., 2., 3., 4., 5., 6.]);
     let b = 3.0;
 
+    // Allocating new memory
+    let c = &a + &b;
+
+    assert_eq!(c[[0, 0]], 4.0);
+    assert_eq!(c[[0, 1]], 5.0);
+    assert_eq!(c[[1, 0]], 6.0);
+    assert_eq!(c[[1, 1]], 7.0);
+    assert_eq!(c[[2, 0]], 8.0);
+    assert_eq!(c[[2, 1]], 9.0);
+
+    // Allocating new memory
+    let c = &a + b;
+
+    assert_eq!(c[[0, 0]], 4.0);
+    assert_eq!(c[[0, 1]], 5.0);
+    assert_eq!(c[[1, 0]], 6.0);
+    assert_eq!(c[[1, 1]], 7.0);
+    assert_eq!(c[[2, 0]], 8.0);
+    assert_eq!(c[[2, 1]], 9.0);
+
+    // Reusing memory
+    let c = a.clone() + &b;
+
+    assert_eq!(c[[0, 0]], 4.0);
+    assert_eq!(c[[0, 1]], 5.0);
+    assert_eq!(c[[1, 0]], 6.0);
+    assert_eq!(c[[1, 1]], 7.0);
+    assert_eq!(c[[2, 0]], 8.0);
+    assert_eq!(c[[2, 1]], 9.0);
+
+    // Reusing memory
     let c = a + b;
 
     assert_eq!(c[[0, 0]], 4.0);
@@ -168,7 +262,38 @@ fn matrix_sub() {
     let a = Matrix::new(3, 2, vec![1., 2., 3., 4., 5., 6.]);
     let b = Matrix::new(3, 2, vec![2., 3., 4., 5., 6., 7.]);
 
-    let c = a - b;
+    // Allocate new memory
+    let c = &a - &b;
+
+    assert_eq!(c[[0, 0]], -1.0);
+    assert_eq!(c[[0, 1]], -1.0);
+    assert_eq!(c[[1, 0]], -1.0);
+    assert_eq!(c[[1, 1]], -1.0);
+    assert_eq!(c[[2, 0]], -1.0);
+    assert_eq!(c[[2, 1]], -1.0);
+
+    // Reusing memory
+    let c = a.clone() - &b;
+
+    assert_eq!(c[[0, 0]], -1.0);
+    assert_eq!(c[[0, 1]], -1.0);
+    assert_eq!(c[[1, 0]], -1.0);
+    assert_eq!(c[[1, 1]], -1.0);
+    assert_eq!(c[[2, 0]], -1.0);
+    assert_eq!(c[[2, 1]], -1.0);
+
+    // Reusing memory
+    let c = &a - b.clone();
+
+    assert_eq!(c[[0, 0]], -1.0);
+    assert_eq!(c[[0, 1]], -1.0);
+    assert_eq!(c[[1, 0]], -1.0);
+    assert_eq!(c[[1, 1]], -1.0);
+    assert_eq!(c[[2, 0]], -1.0);
+    assert_eq!(c[[2, 1]], -1.0);
+
+    // Reusing memory
+    let c = &a - b;
 
     assert_eq!(c[[0, 0]], -1.0);
     assert_eq!(c[[0, 1]], -1.0);
@@ -183,6 +308,37 @@ fn matrix_f32_sub() {
     let a = Matrix::new(3, 2, vec![1., 2., 3., 4., 5., 6.]);
     let b = 3.0;
 
+    // Allocating new memory
+    let c = &a - &b;
+
+    assert_eq!(c[[0, 0]], -2.0);
+    assert_eq!(c[[0, 1]], -1.0);
+    assert_eq!(c[[1, 0]], 0.0);
+    assert_eq!(c[[1, 1]], 1.0);
+    assert_eq!(c[[2, 0]], 2.0);
+    assert_eq!(c[[2, 1]], 3.0);
+
+    // Allocating new memory
+    let c = &a - b;
+
+    assert_eq!(c[[0, 0]], -2.0);
+    assert_eq!(c[[0, 1]], -1.0);
+    assert_eq!(c[[1, 0]], 0.0);
+    assert_eq!(c[[1, 1]], 1.0);
+    assert_eq!(c[[2, 0]], 2.0);
+    assert_eq!(c[[2, 1]], 3.0);
+
+    // Reusing memory
+    let c = a.clone() - &b;
+
+    assert_eq!(c[[0, 0]], -2.0);
+    assert_eq!(c[[0, 1]], -1.0);
+    assert_eq!(c[[1, 0]], 0.0);
+    assert_eq!(c[[1, 1]], 1.0);
+    assert_eq!(c[[2, 0]], 2.0);
+    assert_eq!(c[[2, 1]], 3.0);
+
+    // Reusing memory
     let c = a - b;
 
     assert_eq!(c[[0, 0]], -2.0);
@@ -198,6 +354,37 @@ fn matrix_f32_div() {
     let a = Matrix::new(3, 2, vec![1., 2., 3., 4., 5., 6.]);
     let b = 3.0;
 
+    // Allocating new memory
+    let c = &a / &b;
+
+    assert_eq!(c[[0, 0]], 1.0 / 3.0);
+    assert_eq!(c[[0, 1]], 2.0 / 3.0);
+    assert_eq!(c[[1, 0]], 1.0);
+    assert_eq!(c[[1, 1]], 4.0 / 3.0);
+    assert_eq!(c[[2, 0]], 5.0 / 3.0);
+    assert_eq!(c[[2, 1]], 2.0);
+
+    // Allocating new memory
+    let c = &a / b;
+
+    assert_eq!(c[[0, 0]], 1.0 / 3.0);
+    assert_eq!(c[[0, 1]], 2.0 / 3.0);
+    assert_eq!(c[[1, 0]], 1.0);
+    assert_eq!(c[[1, 1]], 4.0 / 3.0);
+    assert_eq!(c[[2, 0]], 5.0 / 3.0);
+    assert_eq!(c[[2, 1]], 2.0);
+
+    // Reusing memory
+    let c = a.clone() / &b;
+
+    assert_eq!(c[[0, 0]], 1.0 / 3.0);
+    assert_eq!(c[[0, 1]], 2.0 / 3.0);
+    assert_eq!(c[[1, 0]], 1.0);
+    assert_eq!(c[[1, 1]], 4.0 / 3.0);
+    assert_eq!(c[[2, 0]], 5.0 / 3.0);
+    assert_eq!(c[[2, 1]], 2.0);
+
+    // Reusing memory
     let c = a / b;
 
     assert_eq!(c[[0, 0]], 1.0 / 3.0);

--- a/rusty-machine/tests/linalg/mat.rs
+++ b/rusty-machine/tests/linalg/mat.rs
@@ -170,7 +170,7 @@ fn matrix_add() {
     let a = Matrix::new(3, 2, vec![1., 2., 3., 4., 5., 6.]);
     let b = Matrix::new(3, 2, vec![2., 3., 4., 5., 6., 7.]);
 
-    // Reusing memory
+    // Allocating new memory
     let c = &a + &b;
 
     assert_eq!(c[[0, 0]], 3.0);
@@ -180,7 +180,7 @@ fn matrix_add() {
     assert_eq!(c[[2, 0]], 11.0);
     assert_eq!(c[[2, 1]], 13.0);
 
-    // Allocating new memory
+    // Reusing memory
     let c = a.clone() + &b;
 
     assert_eq!(c[[0, 0]], 3.0);
@@ -190,7 +190,7 @@ fn matrix_add() {
     assert_eq!(c[[2, 0]], 11.0);
     assert_eq!(c[[2, 1]], 13.0);
 
-    // Allocating new memory
+    // Reusing memory
     let c = &a + b.clone();
 
     assert_eq!(c[[0, 0]], 3.0);
@@ -200,7 +200,7 @@ fn matrix_add() {
     assert_eq!(c[[2, 0]], 11.0);
     assert_eq!(c[[2, 1]], 13.0);
 
-    // Allocating new memory
+    // Reusing memory
     let c = a + b;
 
     assert_eq!(c[[0, 0]], 3.0);

--- a/rusty-machine/tests/linalg/vector.rs
+++ b/rusty-machine/tests/linalg/vector.rs
@@ -38,6 +38,28 @@ fn vector_f32_mul() {
     let a = Vector::new(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
     let b = 3.0;
 
+    // Allocating new memory
+    let c = &a * &b;
+
+    for i in 0..6 {
+        assert_eq!(c[i], 3.0 * ((i + 1) as f32));
+    }
+
+    // Allocating new memory
+    let c = &a * b;
+
+    for i in 0..6 {
+        assert_eq!(c[i], 3.0 * ((i + 1) as f32));
+    }
+
+    // Reusing memory
+    let c = a.clone() * &b;
+
+    for i in 0..6 {
+        assert_eq!(c[i], 3.0 * ((i + 1) as f32));
+    }
+
+    // Reusing memory
     let c = a * b;
 
     for i in 0..6 {
@@ -50,6 +72,28 @@ fn vector_f32_div() {
     let a = Vector::new(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
     let b = 3.0;
 
+    // Allocating new memory
+    let c = &a / &b;
+
+    for i in 0..6 {
+        assert_eq!(c[i], ((i + 1) as f32) / 3.0);
+    }
+
+    // Allocating new memory
+    let c = &a / b;
+
+    for i in 0..6 {
+        assert_eq!(c[i], ((i + 1) as f32) / 3.0);
+    }
+
+    // Reusing memory
+    let c = a.clone() / &b;
+
+    for i in 0..6 {
+        assert_eq!(c[i], ((i + 1) as f32) / 3.0);
+    }
+
+    // Reusing memory
     let c = a / b;
 
     for i in 0..6 {
@@ -62,6 +106,28 @@ fn vector_add() {
     let a = Vector::new(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
     let b = Vector::new(vec![2.0, 3.0, 4.0, 5.0, 6.0, 7.0]);
 
+    // Allocating new memory
+    let c = &a + &b;
+
+    for i in 0..6 {
+        assert_eq!(c[i], ((2 * i + 3) as f32));
+    }
+
+    // Reusing memory
+    let c = &a + b.clone();
+
+    for i in 0..6 {
+        assert_eq!(c[i], ((2 * i + 3) as f32));
+    }
+
+    // Reusing memory
+    let c = a.clone() + &b;
+
+    for i in 0..6 {
+        assert_eq!(c[i], ((2 * i + 3) as f32));
+    }
+
+    // Reusing memory
     let c = a + b;
 
     for i in 0..6 {
@@ -74,6 +140,28 @@ fn vector_f32_add() {
     let a = Vector::new(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
     let b = 2.0;
 
+    // Allocating new memory
+    let c = &a + &b;
+
+    for i in 0..6 {
+        assert_eq!(c[i], ((i + 1) as f32) + 2.0);
+    }
+
+    // Allocating new memory
+    let c = &a + b;
+
+    for i in 0..6 {
+        assert_eq!(c[i], ((i + 1) as f32) + 2.0);
+    }
+
+    // Reusing memory
+    let c = a.clone() + &b;
+
+    for i in 0..6 {
+        assert_eq!(c[i], ((i + 1) as f32) + 2.0);
+    }
+
+    // Reusing memory
     let c = a + b;
 
     for i in 0..6 {
@@ -86,6 +174,28 @@ fn vector_sub() {
     let a = Vector::new(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
     let b = Vector::new(vec![2.0, 3.0, 4.0, 5.0, 6.0, 7.0]);
 
+    // Allocating new memory
+    let c = &a - &b;
+
+    for i in 0..6 {
+        assert_eq!(c[i], -1.0);
+    }
+
+    // Reusing memory
+    let c = &a - b.clone();
+
+    for i in 0..6 {
+        assert_eq!(c[i], -1.0);
+    }
+
+    // Reusing memory
+    let c = a.clone() - &b;
+
+    for i in 0..6 {
+        assert_eq!(c[i], -1.0);
+    }
+
+    // Reusing memory
     let c = a - b;
 
     for i in 0..6 {
@@ -98,6 +208,28 @@ fn vector_f32_sub() {
     let a = Vector::new(vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
     let b = 2.0;
 
+    // Allocating new memory
+    let c = &a - &b;
+
+    for i in 0..6 {
+        assert_eq!(c[i], ((i + 1) as f32) - 2.0);
+    }
+
+    // Allocating new memory
+    let c = &a - b;
+
+    for i in 0..6 {
+        assert_eq!(c[i], ((i + 1) as f32) - 2.0);
+    }
+
+    // Reusing memory
+    let c = a.clone() - &b;
+
+    for i in 0..6 {
+        assert_eq!(c[i], ((i + 1) as f32) - 2.0);
+    }
+
+    // Reusing memory
     let c = a - b;
 
     for i in 0..6 {
@@ -112,6 +244,4 @@ fn vector_norm() {
     let b = a.norm();
 
     assert_eq!(b, (1. + 4. + 9. + 16. + 25. + 36. as f32).sqrt());
-
-
 }


### PR DESCRIPTION
This solves (largely) issue #26 . It also includes some improvements in terms of vectorization and code re-usability.

The PR includes changes to the underlying binary data operations (sum, subtract, element-wise multiplication, etc.). It also reuses memory when one of the incoming arguments is to be consumed (and has the appropriate size).

One aspect ignored in this PR is the reassignment of matrix data during square matrix multiplication. I figured this is a rare case in the problem domain but should be introduced later.

#### Benches

test linalg::matrix::empty                                 ... bench:               0 ns/iter (+/- 0)
test linalg::matrix::mat_create_100_100         ... bench:        2,734 ns/iter (+/- 254)
test linalg::matrix::mat_create_add_100_100 ... bench:        8,113 ns/iter (+/- 90)
test linalg::matrix::mat_mul_10_10                 ... bench:           283 ns/iter (+/- 5)
test linalg::matrix::mat_old_add_100_100      ... bench:      23,205 ns/iter (+/- 2,158)
test linalg::matrix::mat_ref_add_100_100       ... bench:        6,725 ns/iter (+/- 105)

We can see huge improvements from just the vectorization alone. The new matrix add takes on average 6725 ns/iter compared to the 23,000 ns/iter before. 

We also have a small gain from reusing memory. If we subtract the creation time it costs us an average of 5400 ns/iter to add matrices when we reuse the memory. This gain will be more significant with larger sized matrices (which is common in our domain).