### PR TITLE
Adding Naive Bayes Classifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ There is also a `stats` module behind an optional features flag.
 - Gaussian Process Regression
 - Support Vector Machines
 - Gaussian Mixture Models
+- Naive Bayes Classifiers
 
 ---
 

--- a/rusty-machine/src/learning/naive_bayes.rs
+++ b/rusty-machine/src/learning/naive_bayes.rs
@@ -1,0 +1,482 @@
+//! Naive Bayes Classifiers
+//!
+//! The classifier supports Gaussian, Bernoulli and Multinomial distributions.
+//!
+//! A naive Bayes classifier works by treating the features of each input as independent
+//! observations. Under this assumption we utilize Bayes' rule to compute the probability that each input belongs
+//! to a given class.
+//!
+//! # Examples
+//!
+//! ```
+//! use rusty_machine::learning::naive_bayes::{NaiveBayes, Gaussian};
+//! use rusty_machine::linalg::matrix::Matrix;
+//! use rusty_machine::learning::SupModel;
+//!
+//! let inputs = Matrix::new(6, 2, vec![1.0, 1.1,
+//!                                     1.1, 0.9,
+//!                                     2.2, 2.3,
+//!                                     2.5, 2.7,
+//!                                     5.2, 4.3,
+//!                                     6.2, 7.3]);
+//!
+//! let targets = Matrix::new(6,3, vec![1.0, 0.0, 0.0,
+//!                                     1.0, 0.0, 0.0,
+//!                                     0.0, 1.0, 0.0,
+//!                                     0.0, 1.0, 0.0,
+//!                                     0.0, 0.0, 1.0,
+//!                                     0.0, 0.0, 1.0]);
+//!
+//! // Create a Gaussian Naive Bayes classifier.
+//! let mut model = NaiveBayes::<Gaussian>::new();
+//!
+//! // Train the model.
+//! model.train(&inputs, &targets);
+//!
+//! // Predict the classes on the input data
+//! let outputs = model.predict(&inputs);
+//!
+//! // Will output the target classes - otherwise our classifier is bad!
+//! println!("Final outputs --\n{}", outputs);
+//! ```
+
+use linalg::matrix::Matrix;
+use linalg::utils;
+use learning::SupModel;
+
+use std::f64::consts::PI;
+
+/// The Naive Bayes model.
+#[derive(Debug)]
+pub struct NaiveBayes<T: Distribution> {
+    distr: Option<T>,
+    cluster_count: Option<usize>,
+    class_prior: Option<Vec<f64>>,
+    class_counts: Vec<usize>,
+}
+
+impl<T: Distribution> NaiveBayes<T> {
+    /// Create a new NaiveBayes model from a given
+    /// distribution.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rusty_machine::learning::naive_bayes::{NaiveBayes, Gaussian};
+    ///
+    /// // Create a new Gaussian Naive Bayes model.
+    /// let _ = NaiveBayes::<Gaussian>::new();
+    /// ```
+    pub fn new() -> NaiveBayes<T> {
+        NaiveBayes {
+            distr: None,
+            cluster_count: None,
+            class_prior: None,
+            class_counts: Vec::new(),
+        }
+    }
+
+    /// Get the cluster count for this model.
+    ///
+    /// Returns an option which is `None` until the model has been trained.
+    pub fn cluster_count(&self) -> &Option<usize> {
+        &self.cluster_count
+    }
+
+    /// Get the class prior distribution for this model.
+    ///
+    /// Returns an option which is `None` until the model has been trained.
+    pub fn class_prior(&self) -> &Option<Vec<f64>> {
+        &self.class_prior
+    }
+
+    /// Get the distribution for this model.
+    ///
+    /// Returns an option which is `None` until the model has been trained.
+    pub fn distr(&self) -> &Option<T> {
+        &self.distr
+    }
+}
+
+/// Train and predict from the Naive Bayes model.
+///
+/// The input matrix must be rows made up of features.
+/// The target matrix should have indicator vectors in each row specifying
+/// the input class. e.g. [[1,0,0],[0,0,1]] shows class 1 first, then class 3.
+impl<T: Distribution> SupModel<Matrix<f64>, Matrix<f64>> for NaiveBayes<T> {
+    /// Train the model using inputs and targets.
+    fn train(&mut self, inputs: &Matrix<f64>, targets: &Matrix<f64>) {
+        self.distr = Some(T::from_model_params(targets.cols(), inputs.cols()));
+        self.update_params(inputs, targets);
+    }
+
+    /// Predict output from inputs.
+    fn predict(&self, inputs: &Matrix<f64>) -> Matrix<f64> {
+        let log_probs = self.get_log_probs(inputs);
+        let input_classes = NaiveBayes::<T>::get_classes(log_probs);
+
+        if let Some(cluster_count) = self.cluster_count {
+            let mut class_data = Vec::with_capacity(inputs.rows() * cluster_count);
+
+            for c in input_classes {
+                let mut row = vec![0f64; cluster_count];
+                row[c] = 1f64;
+
+                class_data.append(&mut row);
+            }
+
+            Matrix::new(inputs.rows(), cluster_count, class_data)
+        } else {
+            panic!("The model has not been trained.");
+        }
+    }
+}
+
+impl<T: Distribution> NaiveBayes<T> {
+    /// Get the log-probabilities per class for each input.
+    pub fn get_log_probs(&self, inputs: &Matrix<f64>) -> Matrix<f64> {
+
+        if let (&Some(ref distr), &Some(ref prior)) = (&self.distr, &self.class_prior) {
+            // Get the joint log likelihood from the distribution
+            distr.joint_log_lik(inputs, prior)
+        } else {
+            panic!("Model has not been trained.");
+        }
+    }
+
+    fn update_params(&mut self, inputs: &Matrix<f64>, targets: &Matrix<f64>) {
+        let class_count = targets.cols();
+        let total_data = inputs.rows();
+
+        self.class_counts = vec![0; class_count];
+        let mut class_data = vec![Vec::new(); class_count];
+
+        for (idx, row) in targets.data().chunks(class_count).enumerate() {
+            // Find the class of this input
+            let class = NaiveBayes::<T>::find_class(row);
+
+            // Note the class of the input
+            class_data[class].push(idx);
+            self.class_counts[class] += 1;
+        }
+
+        if let Some(ref mut distr) = self.distr {
+            for (idx, c) in class_data.into_iter().enumerate() {
+                // Update the parameters within this class
+                distr.update_params(inputs.select_rows(&c), idx);
+            }
+        }
+
+        let mut class_prior = Vec::with_capacity(class_count);
+
+        // Compute the prior as the proportion in each class
+        for i in 0..class_count {
+            class_prior.push(self.class_counts[i] as f64 / total_data as f64);
+        }
+
+        self.class_prior = Some(class_prior);
+        self.cluster_count = Some(class_count);
+    }
+
+    fn find_class(row: &[f64]) -> usize {
+        // Find the `1` entry in the row
+        for (idx, r) in row.into_iter().enumerate() {
+            if *r == 1f64 {
+                return idx;
+            }
+        }
+        panic!("No class found for entry in targets");
+    }
+
+    fn get_classes(log_probs: Matrix<f64>) -> Vec<usize> {
+        let class_count = log_probs.cols();
+        let mut data_classes = Vec::with_capacity(log_probs.rows());
+
+        // Argmax each class log-probability per input
+        for row in log_probs.data().chunks(class_count) {
+            let (class, _) = utils::argmax(row);
+
+            data_classes.push(class);
+        }
+
+        data_classes
+    }
+}
+
+/// Naive Bayes Distribution.
+pub trait Distribution {
+    /// Initialize the distribution parameters.
+    fn from_model_params(class_count: usize, features: usize) -> Self;
+
+    /// Updates the distribution parameters.
+    fn update_params(&mut self, data: Matrix<f64>, class: usize);
+
+    /// Compute the joint log likelihood of the data.
+    ///
+    /// Returns a matrix with rows containing the probability that the input lies in each class.
+    fn joint_log_lik(&self, data: &Matrix<f64>, class_prior: &[f64]) -> Matrix<f64>;
+}
+
+/// The Gaussian Naive Bayes model distribution.
+///
+/// Defines:
+///
+///    p(x|C<sub>k</sub>) = ∏<sub>i</sub> N(x<sub>i</sub> ; μ<sub>k</sub>, σ<sup>2</sup><sub>k</sub>)
+#[derive(Debug)]
+pub struct Gaussian {
+    theta: Matrix<f64>,
+    sigma: Matrix<f64>,
+}
+
+impl Gaussian {
+    /// Returns the distribution means.
+    ///
+    /// This is a matrix of class by feature means.
+    pub fn theta(&self) -> &Matrix<f64> {
+        &self.theta
+    }
+
+    /// Returns the distribution variances.
+    ///
+    /// This is a matrix of class by feature variances.
+    pub fn sigma(&self) -> &Matrix<f64> {
+        &self.sigma
+    }
+}
+
+impl Distribution for Gaussian {
+    fn from_model_params(class_count: usize, features: usize) -> Gaussian {
+        Gaussian {
+            theta: Matrix::zeros(class_count, features),
+            sigma: Matrix::zeros(class_count, features),
+        }
+    }
+
+    fn update_params(&mut self, data: Matrix<f64>, class: usize) {
+        // Compute mean and sample variance
+        let mean = data.mean(0).into_vec();
+        let var = data.variance(0).into_vec();
+
+        let features = data.cols();
+
+        for (idx, (m, v)) in mean.into_iter().zip(var.into_iter()).enumerate() {
+            self.theta.mut_data()[class * features + idx] = m;
+            self.sigma.mut_data()[class * features + idx] = v;
+        }
+    }
+
+    fn joint_log_lik(&self, data: &Matrix<f64>, class_prior: &[f64]) -> Matrix<f64> {
+        let class_count = class_prior.len();
+        let mut log_lik = Vec::with_capacity(class_count);
+
+        for i in 0..class_count {
+            let joint_i = class_prior[i].ln();
+            let n_ij = -0.5 * (self.sigma.select_rows(&[i]) * 2.0 * PI).apply(&|x| x.ln()).sum();
+
+            // NOTE: Here we are copying the row data which is inefficient
+            let r_ij = (data - self.theta.select_rows(&vec![i; data.rows()]))
+                           .apply(&|x| x * x)
+                           .elediv(&self.sigma.select_rows(&vec![i; data.rows()]))
+                           .sum_cols();
+
+            let res = (-r_ij * 0.5) + n_ij;
+
+
+            log_lik.append(&mut (res + joint_i).into_vec());
+        }
+
+        Matrix::new(class_count, data.rows(), log_lik).transpose()
+    }
+}
+
+/// The Bernoulli Naive Bayes model distribution.
+///
+/// Defines:
+///
+///    p(x|C<sub>k</sub>) = ∏<sub>i</sub> p<sub>k</sub><sup>x<sub>i</sub></sup> (1-p)<sub>k</sub><sup>1-x<sub>i</sub></sup>
+#[derive(Debug)]
+pub struct Bernoulli {
+    log_probs: Matrix<f64>,
+    pseudo_count: f64,
+}
+
+impl Bernoulli {
+    /// The log probability matrix.
+    ///
+    /// A matrix of class by feature model log-probabilities.
+    pub fn log_probs(&self) -> &Matrix<f64> {
+        &self.log_probs
+    }
+}
+
+impl Distribution for Bernoulli {
+    fn from_model_params(class_count: usize, features: usize) -> Bernoulli {
+        Bernoulli {
+            log_probs: Matrix::zeros(class_count, features),
+            pseudo_count: 1f64,
+        }
+    }
+
+    fn update_params(&mut self, data: Matrix<f64>, class: usize) {
+        let features = data.cols();
+
+        // We add the pseudo count to the class count and feature count
+        let pseudo_cc = data.rows() as f64 + (2f64 * self.pseudo_count);
+        let pseudo_fc = data.sum_rows() + self.pseudo_count;
+
+        let log_probs = (pseudo_fc.apply(&|x| x.ln()) - pseudo_cc.ln()).into_vec();
+
+        for i in 0..features {
+            self.log_probs[[class, i]] = log_probs[i];
+        }
+
+    }
+
+    fn joint_log_lik(&self, data: &Matrix<f64>, class_prior: &[f64]) -> Matrix<f64> {
+        let class_count = class_prior.len();
+
+        let neg_prob = self.log_probs.clone().apply(&|x| (1f64 - x.exp()).ln());
+
+        let res = data * (&self.log_probs - &neg_prob).transpose();
+
+        // NOTE: Some messy stuff now to get the class row contribution.
+        // Really we want to add to each row the class log-priors and the
+        // neg_prob_sum contribution - the last term in
+        // x log(p) + (1-x)log(1-p) = x (log(p) - log(1-p)) + log(1-p)
+
+        let mut per_class_row = Vec::with_capacity(class_count);
+        let neg_prob_sum = neg_prob.sum_cols();
+
+        for (idx, p) in class_prior.into_iter().enumerate() {
+            per_class_row.push(p.ln() + neg_prob_sum[idx]);
+        }
+
+        let class_row_mat = Matrix::new(1, class_count, per_class_row);
+
+        res + class_row_mat.select_rows(&vec![0; data.rows()])
+    }
+}
+
+/// The Multinomial Naive Bayes model distribution.
+///
+/// Defines:
+///
+///    p(x|C<sub>k</sub>) ∝ ∏<sub>i</sub> p<sub>k</sub><sup>x<sub>i</sub></sup>
+#[derive(Debug)]
+pub struct Multinomial {
+    log_probs: Matrix<f64>,
+    pseudo_count: f64,
+}
+
+impl Multinomial {
+    /// The log probability matrix.
+    ///
+    /// A matrix of class by feature model log-probabilities.
+    pub fn log_probs(&self) -> &Matrix<f64> {
+        &self.log_probs
+    }
+}
+
+impl Distribution for Multinomial {
+    fn from_model_params(class_count: usize, features: usize) -> Multinomial {
+        Multinomial {
+            log_probs: Matrix::zeros(class_count, features),
+            pseudo_count: 1f64,
+        }
+    }
+
+    fn update_params(&mut self, data: Matrix<f64>, class: usize) {
+        let features = data.cols();
+
+        let pseudo_fc = data.sum_rows() + self.pseudo_count;
+        let pseudo_cc = pseudo_fc.sum();
+
+        let log_probs = (pseudo_fc.apply(&|x| x.ln()) - pseudo_cc.ln()).into_vec();
+
+        for i in 0..features {
+            self.log_probs[[class, i]] = log_probs[i];
+        }
+
+    }
+
+    fn joint_log_lik(&self, data: &Matrix<f64>, class_prior: &[f64]) -> Matrix<f64> {
+        let class_count = class_prior.len();
+
+        let res = data * self.log_probs.transpose();
+
+        let mut per_class_row = Vec::with_capacity(class_count);
+        for p in class_prior {
+            per_class_row.push(p.ln());
+        }
+
+        let class_row_mat = Matrix::new(1, class_count, per_class_row);
+
+        res + class_row_mat.select_rows(&vec![0; data.rows()])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NaiveBayes;
+    use super::Gaussian;
+    use super::Bernoulli;
+    use super::Multinomial;
+
+    use super::super::SupModel;
+
+    use super::super::super::linalg::matrix::Matrix;
+
+    #[test]
+    fn test_gaussian() {
+        let inputs = Matrix::new(6,
+                                 2,
+                                 vec![1.0, 1.1, 1.1, 0.9, 2.2, 2.3, 2.5, 2.7, 5.2, 4.3, 6.2, 7.3]);
+
+        let targets = Matrix::new(6,
+                                  3,
+                                  vec![1.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0,
+                                       0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0]);
+
+        let mut model = NaiveBayes::<Gaussian>::new();
+        model.train(&inputs, &targets);
+
+        let outputs = model.predict(&inputs);
+
+        assert_eq!(outputs.into_vec(), targets.into_vec());
+    }
+
+    #[test]
+    fn test_bernoulli() {
+        let inputs = Matrix::new(4,
+                                 3,
+                                 vec![1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 1.0, 1.0, 0.0, 1.0, 0.0, 0.0]);
+
+        let targets = Matrix::new(4, 2, vec![1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0]);
+
+        let mut model = NaiveBayes::<Bernoulli>::new();
+        model.train(&inputs, &targets);
+
+        let outputs = model.predict(&inputs);
+        println!("{}", outputs);
+
+        assert_eq!(outputs.into_vec(), targets.into_vec());
+    }
+
+    #[test]
+    fn test_multinomial() {
+        let inputs = Matrix::new(4,
+                                 3,
+                                 vec![1.0, 0.0, 5.0, 0.0, 0.0, 11.0, 13.0, 1.0, 0.0, 12.0, 3.0,
+                                      0.0]);
+
+        let targets = Matrix::new(4, 2, vec![1.0, 0.0, 1.0, 0.0, 0.0, 1.0, 0.0, 1.0]);
+
+        let mut model = NaiveBayes::<Multinomial>::new();
+        model.train(&inputs, &targets);
+
+        let outputs = model.predict(&inputs);
+        println!("{}", outputs);
+
+        assert_eq!(outputs.into_vec(), targets.into_vec());
+    }
+}

--- a/rusty-machine/src/lib.rs
+++ b/rusty-machine/src/lib.rs
@@ -22,7 +22,8 @@
 //! - Neural Networks
 //! - Gaussian Process Regression
 //! - Support Vector Machines
-//! - Gaussian Mixture Modelss
+//! - Gaussian Mixture Models
+//! - Naive Bayes Classifiers
 //!
 //! ### linalg
 //!
@@ -114,6 +115,7 @@ pub mod learning {
     pub mod nnet;
     pub mod gp;
     pub mod svm;
+    pub mod naive_bayes;
 
     /// Trait for supervised model.
     pub trait SupModel<T,U> {

--- a/rusty-machine/src/linalg/matrix/mod.rs
+++ b/rusty-machine/src/linalg/matrix/mod.rs
@@ -211,13 +211,10 @@ impl<T: Copy> Matrix<T> {
                     "Row index is greater than number of rows.");
         }
 
-        unsafe {
-            for row in rows {
-                for i in 0..self.cols {
-                    mat_vec.push(*self.data.get_unchecked(*row * self.cols + i));
-                }
-            }
+        for row in rows {
+            mat_vec.extend_from_slice(&self.data[*row * self.cols..(*row+1) * self.cols]);
         }
+
         Matrix {
             cols: self.cols,
             rows: rows.len(),
@@ -1700,5 +1697,32 @@ mod tests {
         }
 
         assert_eq!(a[[0,0]], 13.0);
+    }
+
+    #[test]
+    fn test_matrix_select_rows() {
+        let a = Matrix::new(4,2, (0..8).collect::<Vec<usize>>());
+
+        let b = a.select_rows(&[0,2,3]);
+
+        assert_eq!(b.into_vec(), vec![0,1,4,5,6,7]);
+    }
+
+    #[test]
+    fn test_matrix_select_cols() {
+        let a = Matrix::new(4,2, (0..8).collect::<Vec<usize>>());
+
+        let b = a.select_cols(&[1]);
+
+        assert_eq!(b.into_vec(), vec![1,3,5,7]);
+    }
+
+    #[test]
+    fn test_matrix_select() {
+        let a = Matrix::new(4,2, (0..8).collect::<Vec<usize>>());
+
+        let b = a.select(&[0,2], &[1]);
+
+        assert_eq!(b.into_vec(), vec![1,5]);
     }
 }


### PR DESCRIPTION
Adding a simple implementation of Naive Bayes Classifiers. Only support single pass training.

This PR includes Gaussian, Multinomial and Bernoulli models. The following have not been included in this PR but would be nice:

- Checking model inputs (Bernoulli is flags, Multinomial is counts, etc.).
- Allowing specification of pseudo counts on the discrete models.
- Partial training (so we can go in batches).

If anyone has suggestions on how we can tackle these as part of this PR I'd be happy to hear it!