### PR TITLE
Matrixmultiply

### DIFF
--- a/rusty-machine/Cargo.toml
+++ b/rusty-machine/Cargo.toml
@@ -16,3 +16,4 @@ stats = []
 [dependencies]
 num = {version = "0.1.31", default-features = false }
 rand = "0.3.14"
+matrixmultiply = "0.1.8"

--- a/rusty-machine/benches/linalg/matrix.rs
+++ b/rusty-machine/benches/linalg/matrix.rs
@@ -38,8 +38,26 @@ fn mat_create_100_100(b: &mut Bencher) {
 #[bench]
 fn mat_mul_10_10(b: &mut Bencher) {
 
-    let a = Matrix::new(10, 10, vec![2.0;100]);
-    let c = Matrix::new(10, 10, vec![3.0;100]);
+    let a = Matrix::new(10, 10, vec![2f32; 100]);
+    let c = Matrix::new(10, 10, vec![3f32; 100]);
+
+    b.iter(|| &a * &c)
+}
+
+#[bench]
+fn mat_mul_128_100(b: &mut Bencher) {
+
+    let a = Matrix::new(128, 100, vec![2f32; 12800]);
+    let c = Matrix::new(100, 128, vec![3f32; 12800]);
+
+    b.iter(|| &a * &c)
+}
+
+#[bench]
+fn mat_mul_128_1000(b: &mut Bencher) {
+
+    let a = Matrix::new(128, 1000, vec![2f32; 128000]);
+    let c = Matrix::new(1000, 128, vec![3f32; 128000]);
 
     b.iter(|| &a * &c)
 }

--- a/rusty-machine/src/lib.rs
+++ b/rusty-machine/src/lib.rs
@@ -95,6 +95,7 @@
 
 extern crate num as libnum;
 extern crate rand;
+extern crate matrixmultiply;
 
 pub mod prelude;
 

--- a/rusty-machine/src/linalg/matrix/decomposition.rs
+++ b/rusty-machine/src/linalg/matrix/decomposition.rs
@@ -5,6 +5,7 @@
 
 use std::ops::{Mul, Add, Div, Sub, Neg};
 use std::cmp;
+use std::any::Any;
 
 use linalg::matrix::Matrix;
 use linalg::vector::Vector;
@@ -14,7 +15,7 @@ use linalg::utils;
 use libnum::{One, Zero, Float, NumCast, Signed};
 use libnum::{cast, abs};
 
-impl<T: Copy + Zero + Float> Matrix<T> {
+impl<T: Any  + Float> Matrix<T> {
     /// Cholesky decomposition
     ///
     /// Returns the cholesky decomposition of a positive definite matrix.
@@ -159,7 +160,7 @@ impl<T: Copy + Zero + Float> Matrix<T> {
     }
 }
 
-impl<T: Copy + Zero + One + Float + NumCast + Signed> Matrix<T> {
+impl<T: Any + Float + Signed> Matrix<T> {
     /// Returns H, where H is the upper hessenberg form.
     ///
     /// If the transformation matrix is also required, you should
@@ -610,7 +611,7 @@ impl<T: Copy + Zero + One + Float + NumCast + Signed> Matrix<T> {
 }
 
 
-impl<T> Matrix<T> where T: Copy + One + Zero + Neg<Output=T> +
+impl<T> Matrix<T> where T: Any + Copy + One + Zero + Neg<Output=T> +
                            Add<T, Output=T> + Mul<T, Output=T> +
                            Sub<T, Output=T> + Div<T, Output=T> +
                            PartialOrd {

--- a/rusty-machine/src/linalg/matrix/mat_mul.rs
+++ b/rusty-machine/src/linalg/matrix/mat_mul.rs
@@ -1,0 +1,243 @@
+use super::{Matrix, MatrixSlice, MatrixSliceMut};
+use super::slice::BaseSlice;
+
+use std::any::{Any, TypeId};
+use std::ops::{Add, Mul};
+
+use libnum::Zero;
+use matrixmultiply;
+
+#[inline(always)]
+/// Return `true` if `A` and `B` are the same type
+fn same_type<A: Any, B: Any>() -> bool {
+    TypeId::of::<A>() == TypeId::of::<B>()
+}
+
+macro_rules! impl_mat_mul (
+    ($mat_1:ident, $mat_2:ident) => (
+
+/// Multiplies two matrices together.
+impl<T: Any + Copy + Zero + Add<T, Output=T> + Mul<T, Output=T>> Mul<$mat_2<T>> for $mat_1<T> {
+    type Output = Matrix<T>;
+
+    fn mul(self, m: $mat_2<T>) -> Matrix<T> {
+        (&self) * (&m)
+    }
+}
+
+/// Multiplies two matrices together.
+impl<'a, T: Any + Copy + Zero + Add<T, Output=T> + Mul<T, Output=T>> Mul<&'a $mat_2<T>> for $mat_1<T> {
+    type Output = Matrix<T>;
+
+    fn mul(self, m: &$mat_2<T>) -> Matrix<T> {
+        (&self) * (m)
+    }
+}
+
+/// Multiplies two matrices together.
+impl<'a, T: Any + Copy + Zero + Add<T, Output=T> + Mul<T, Output=T>> Mul<$mat_2<T>> for &'a $mat_1<T> {
+    type Output = Matrix<T>;
+
+    fn mul(self, m: $mat_2<T>) -> Matrix<T> {
+        (self) * (&m)
+    }
+}
+
+/// Multiplies two matrices together.
+impl<'a, 'b, T: Any + Copy + Zero + Add<T, Output=T> + Mul<T, Output=T>> Mul<&'b $mat_2<T>> for &'a $mat_1<T> {
+    type Output = Matrix<T>;
+
+    fn mul(self, m: &$mat_2<T>) -> Matrix<T> {
+        assert!(self.cols == m.rows, "Matrix dimensions do not agree.");
+
+        let p = self.rows;
+        let q = self.cols;
+        let r = m.cols;
+
+        if same_type::<T, f32>() {
+            let mut new_data = Vec::with_capacity(p * r);
+            
+            unsafe {
+                new_data.set_len(p * r);
+
+                matrixmultiply::sgemm(
+                    p, q, r,
+                    1f32,
+                    self.as_ptr() as *const _,
+                    q as isize, 1,
+                    m.as_ptr() as *const _,
+                    r as isize, 1,
+                    0f32,
+                    new_data.as_mut_ptr() as *mut _,
+                    r as isize, 1
+                    );
+            }
+
+            Matrix {
+                rows: p,
+                cols: r,
+                data: new_data
+            }
+        } else if same_type::<T, f64>() {
+            let mut new_data = Vec::with_capacity(p * r);
+
+            unsafe {
+                new_data.set_len(p * r);
+
+                matrixmultiply::dgemm(
+                    p, q, r,
+                    1f64,
+                    self.as_ptr() as *const _,
+                    q as isize, 1,
+                    m.as_ptr() as *const _,
+                    r as isize, 1,
+                    0f64,
+                    new_data.as_mut_ptr() as *mut _,
+                    r as isize, 1
+                    );
+            }
+
+            Matrix {
+                rows: p,
+                cols: r,
+                data: new_data
+            }
+
+        } else {
+            let mut new_data = vec![T::zero(); p * r];
+
+            unsafe {
+                for i in 0..p
+                {
+                    for k in 0..q
+                    {
+                        for j in 0..r
+                        {
+                            new_data[i*r + j] = *new_data.get_unchecked(i*r + j) + *self.get_unchecked([i,k]) * *m.get_unchecked([k,j]);
+                        }
+                    }
+                }
+            }
+
+            Matrix {
+                rows: self.rows,
+                cols: m.cols,
+                data: new_data
+            }
+        }
+    }
+}
+    );
+);
+
+impl_mat_mul!(Matrix, Matrix);
+impl_mat_mul!(Matrix, MatrixSlice);
+impl_mat_mul!(Matrix, MatrixSliceMut);
+impl_mat_mul!(MatrixSlice, Matrix);
+impl_mat_mul!(MatrixSlice, MatrixSlice);
+impl_mat_mul!(MatrixSlice, MatrixSliceMut);
+impl_mat_mul!(MatrixSliceMut, Matrix);
+impl_mat_mul!(MatrixSliceMut, MatrixSlice);
+impl_mat_mul!(MatrixSliceMut, MatrixSliceMut);
+
+#[cfg(test)]
+mod tests {
+    use super::super::Matrix;
+    use super::super::MatrixSlice;
+    use super::super::MatrixSliceMut;
+
+    #[test]
+    fn matrix_mul_f32() {
+        let a = Matrix::new(3, 2, vec![1f32, 2., 3., 4., 5., 6.]);
+        let b = Matrix::new(2, 3, vec![1f32, 2., 3., 4., 5., 6.]);
+
+        // Allocating new memory
+        let c = &a * &b;
+
+        assert_eq!(c.rows(), 3);
+        assert_eq!(c.cols(), 3);
+
+        assert_eq!(c[[0, 0]], 9.0);
+        assert_eq!(c[[0, 1]], 12.0);
+        assert_eq!(c[[0, 2]], 15.0);
+        assert_eq!(c[[1, 0]], 19.0);
+        assert_eq!(c[[1, 1]], 26.0);
+        assert_eq!(c[[1, 2]], 33.0);
+        assert_eq!(c[[2, 0]], 29.0);
+        assert_eq!(c[[2, 1]], 40.0);
+        assert_eq!(c[[2, 2]], 51.0);
+    }
+
+    #[test]
+    fn matrix_mul_f64() {
+        let a = Matrix::new(3, 2, vec![1f64, 2., 3., 4., 5., 6.]);
+        let b = Matrix::new(2, 3, vec![1f64, 2., 3., 4., 5., 6.]);
+
+        // Allocating new memory
+        let c = &a * &b;
+
+        assert_eq!(c.rows(), 3);
+        assert_eq!(c.cols(), 3);
+
+        assert_eq!(c[[0, 0]], 9.0);
+        assert_eq!(c[[0, 1]], 12.0);
+        assert_eq!(c[[0, 2]], 15.0);
+        assert_eq!(c[[1, 0]], 19.0);
+        assert_eq!(c[[1, 1]], 26.0);
+        assert_eq!(c[[1, 2]], 33.0);
+        assert_eq!(c[[2, 0]], 29.0);
+        assert_eq!(c[[2, 1]], 40.0);
+        assert_eq!(c[[2, 2]], 51.0);
+    }
+
+    #[test]
+    fn matrix_mul_usize() {
+        let a = Matrix::new(3, 2, vec![1usize, 2, 3, 4, 5, 6]);
+        let b = Matrix::new(2, 3, vec![1usize, 2, 3, 4, 5, 6]);
+
+        // Allocating new memory
+        let c = &a * &b;
+
+        assert_eq!(c.rows(), 3);
+        assert_eq!(c.cols(), 3);
+
+        assert_eq!(c[[0, 0]], 9);
+        assert_eq!(c[[0, 1]], 12);
+        assert_eq!(c[[0, 2]], 15);
+        assert_eq!(c[[1, 0]], 19);
+        assert_eq!(c[[1, 1]], 26);
+        assert_eq!(c[[1, 2]], 33);
+        assert_eq!(c[[2, 0]], 29);
+        assert_eq!(c[[2, 1]], 40);
+        assert_eq!(c[[2, 2]], 51);
+    }
+
+    #[test]
+    fn mul_slice() {
+        let a = 3.0;
+        let b = Matrix::new(2, 2, vec![1.0; 4]);
+        let mut c = Matrix::new(3, 3, vec![2.0; 9]);
+
+        let d = MatrixSlice::from_matrix(&c, [1, 1], 2, 2);
+
+        let m_1 = &d * a.clone();
+        assert_eq!(m_1.into_vec(), vec![6.0; 4]);
+
+        let m_2 = &d * b.clone();
+        assert_eq!(m_2.into_vec(), vec![4.0; 4]);
+
+        let m_3 = &d * &d;
+        assert_eq!(m_3.into_vec(), vec![8.0; 4]);
+
+        let e = MatrixSliceMut::from_matrix(&mut c, [1, 1], 2, 2);
+
+        let m_1 = &e * a;
+        assert_eq!(m_1.into_vec(), vec![6.0; 4]);
+
+        let m_2 = &e * b;
+        assert_eq!(m_2.into_vec(), vec![4.0; 4]);
+
+        let m_3 = &e * &e;
+        assert_eq!(m_3.into_vec(), vec![8.0; 4]);
+    }
+}

--- a/rusty-machine/src/linalg/matrix/mod.rs
+++ b/rusty-machine/src/linalg/matrix/mod.rs
@@ -3,6 +3,7 @@
 //! Currently contains all code
 //! relating to the matrix linear algebra struct.
 
+use std::any::Any;
 use std::fmt;
 use std::ops::{Mul, Add, Div, Sub, Neg};
 use libnum::{One, Zero, Float, FromPrimitive};
@@ -13,6 +14,7 @@ use linalg::utils;
 
 mod decomposition;
 mod impl_ops;
+mod mat_mul;
 pub mod slice;
 
 /// Matrix dimensions
@@ -120,6 +122,11 @@ impl<T> Matrix<T> {
     /// Get a mutable reference to a point in the matrix without bounds checks.
     pub unsafe fn get_unchecked_mut(&mut self, index: [usize; 2]) -> &T {
         self.data.get_unchecked_mut(index[0] * self.cols + index[1])
+    }
+
+    /// Returns pointer to first element of underlying data.
+    pub fn as_ptr(&self) -> *const T {
+        self.data.as_ptr()
     }
 
     /// Consumes the Matrix and returns the Vec of data.
@@ -866,7 +873,7 @@ impl<T: Copy + Zero + Float + FromPrimitive> Matrix<T> {
     }
 }
 
-impl<T> Matrix<T> where T: Copy + One + Zero + Neg<Output=T> +
+impl<T> Matrix<T> where T: Any + Copy + One + Zero + Neg<Output=T> +
                            Add<T, Output=T> + Mul<T, Output=T> +
                            Sub<T, Output=T> + Div<T, Output=T> +
                            PartialOrd {

--- a/rusty-machine/src/linalg/utils.rs
+++ b/rusty-machine/src/linalg/utils.rs
@@ -141,6 +141,21 @@ pub fn in_place_vec_bin_op<F, T: Copy>(mut u: &mut [T], v: &[T], mut f: F)
         }
 }
 
+/// Vectorized binary operation applied to two slices.
+///
+/// # Examples
+///
+/// ```
+/// use rusty_machine::linalg::utils;
+///
+/// let mut a = vec![2.0; 10];
+/// let b = vec![3.0; 10];
+///
+/// let c = utils::vec_bin_op(&a, &b, |x, y| { 1f64 + x * y });
+///
+/// // Will print a vector of `7`s.
+/// println!("{:?}", a);
+/// ```
 pub fn vec_bin_op<F, T: Copy>(u: &[T], v: &[T], f: F) -> Vec<T>
     where F: Fn(T, T) -> T {
         debug_assert_eq!(u.len(), v.len());


### PR DESCRIPTION
This gives us huge speedups for matrix multiplication:

> Before:
> 
> test linalg::matrix::mat_mul_128_1000 ... bench: 14,231,183 ns/iter (+/- 833,129)
> 
> After:
> 
> test linalg::matrix::mat_mul_128_1000 ... bench: 3,352,754 ns/iter (+/- 412,408)

This change only applies for f32 and f64 multiplication. The PR adds some more complex trait bounds (requiring `Any` on many implementation blocks). Once specialization lands this can be removed.

This resolve #38 .