### PR TITLE
derive PartialEq for Matrix and Vector

### DIFF
--- a/rusty-machine/src/linalg/matrix/mod.rs
+++ b/rusty-machine/src/linalg/matrix/mod.rs
@@ -29,7 +29,7 @@ pub enum Axes {
 /// The Matrix struct.
 ///
 /// Can be instantiated with any type.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Matrix<T> {
     rows: usize,
     cols: usize,
@@ -1182,6 +1182,13 @@ mod tests {
     use super::Matrix;
     use super::Axes;
     use super::slice::BaseSlice;
+
+    #[test]
+    fn test_equality() { // well, "PartialEq", at least
+        let a = Matrix::new(2, 3, vec![1., 2., 3., 4., 5., 6.]);
+        let a_redux = a.clone();
+        assert_eq!(a, a_redux);
+    }
 
     #[test]
     fn test_display_formatting() {

--- a/rusty-machine/src/linalg/vector.rs
+++ b/rusty-machine/src/linalg/vector.rs
@@ -12,7 +12,7 @@ use linalg::utils;
 /// The Vector struct.
 ///
 /// Can be instantiated with any type.
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Vector<T> {
     size: usize,
     data: Vec<T>,
@@ -646,4 +646,18 @@ impl<T: Float> Metric<T> for Vector<T> {
 
         s.sqrt()
     }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::Vector;
+
+    #[test]
+    fn test_equality() {
+        let v = Vector::new(vec![1, 2, 3, 4]);
+        let v_redux = v.clone();
+        assert_eq!(v, v_redux);
+    }
+
 }


### PR DESCRIPTION
Any reason not to do this?

(Previously—

```
<std macros>:5:8: 5:18 error: binary operation `==` cannot be applied to type `linalg::matrix::Matrix<_>` [E0369]
<std macros>:5 if ! ( * left_val == * right_val ) {
                      ^~~~~~~~~~
src/linalg/matrix/mod.rs:1190:9: 1190:32 note: in this expansion of assert_eq! (defined in <std macros>)
<std macros>:5:8: 5:18 help: run `rustc --explain E0369` to see a detailed explanation
<std macros>:5:8: 5:18 note: an implementation of `std::cmp::PartialEq` might be missing for `linalg::matrix::Matrix<_>`
<std macros>:5 if ! ( * left_val == * right_val ) {
                      ^~~~~~~~~~
src/linalg/matrix/mod.rs:1190:9: 1190:32 note: in this expansion of assert_eq! (defined in <std macros>)
```
)