### PR TITLE
Matrix and Vector constructors accept data as Into<Vec<T>>?

### DIFF
--- a/rusty-machine/src/linalg/matrix/impl_ops.rs
+++ b/rusty-machine/src/linalg/matrix/impl_ops.rs
@@ -1115,7 +1115,7 @@ mod tests {
 
     #[test]
     fn index_slice() {
-        let mut b = Matrix::new(3, 3, (0..9).collect());
+        let mut b = Matrix::new(3, 3, (0..9).collect::<Vec<_>>());
 
         let c = MatrixSlice::from_matrix(&b, [1, 1], 2, 2);
 
@@ -1187,7 +1187,7 @@ mod tests {
     #[test]
     fn matrix_sub_assign() {
         let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<i32>>());
-        
+
         a -= &2;
         assert_eq!(a.into_vec(), (-2..7).collect::<Vec<_>>());
 
@@ -1312,7 +1312,7 @@ mod tests {
     fn slice_sub_assign() {
         let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<i32>>());
         let mut a_slice = MatrixSliceMut::from_matrix(&mut a, [0,0], 3, 3);
-        
+
         a_slice -= &2;
         assert_eq!(a.into_vec(), (-2..7).collect::<Vec<_>>());
 

--- a/rusty-machine/src/linalg/matrix/mod.rs
+++ b/rusty-machine/src/linalg/matrix/mod.rs
@@ -84,14 +84,15 @@ impl<T> Matrix<T> {
     /// # Panics
     ///
     /// - The input data does not match the given dimensions.
-    pub fn new(rows: usize, cols: usize, data: Vec<T>) -> Matrix<T> {
+    pub fn new<U: Into<Vec<T>>>(rows: usize, cols: usize, data: U) -> Matrix<T> {
+        let our_data = data.into();
 
-        assert!(cols * rows == data.len(),
+        assert!(cols * rows == our_data.len(),
                 "Data does not match given dimensions.");
         Matrix {
             cols: cols,
             rows: rows,
-            data: data,
+            data: our_data,
         }
     }
 
@@ -1211,6 +1212,15 @@ mod tests {
     }
 
     #[test]
+    fn test_new_from_slice() {
+        let data_vec: Vec<u32> = vec![1, 2, 3, 4, 5, 6];
+        let data_slice: &[u32] = &data_vec[..];
+        let from_vec = Matrix::new(3, 2, data_vec.clone());
+        let from_slice = Matrix::new(3, 2, data_slice);
+        assert_eq!(from_vec, from_slice);
+    }
+
+    #[test]
     fn test_display_formatting() {
         let first_matrix = Matrix::new(2, 3, vec![1, 2, 3, 4, 5, 6]);
         let first_expectation = "⎡1 2 3⎤\n\
@@ -1259,7 +1269,7 @@ mod tests {
 
     #[test]
     fn test_split_matrix() {
-        let a = Matrix::new(3, 3, (0..9).collect());
+        let a = Matrix::new(3, 3, (0..9).collect::<Vec<_>>());
 
         let (b,c) = a.split_at(1, Axes::Row);
 
@@ -1281,7 +1291,7 @@ mod tests {
 
     #[test]
     fn test_split_matrix_mut() {
-        let mut a = Matrix::new(3, 3, (0..9).collect());
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<_>>());
 
         let (mut b, mut c) = a.split_at_mut(1, Axes::Row);
 

--- a/rusty-machine/src/linalg/matrix/slice.rs
+++ b/rusty-machine/src/linalg/matrix/slice.rs
@@ -8,7 +8,7 @@
 //! use rusty_machine::linalg::matrix::MatrixSlice;
 //!
 //! let a = Matrix::new(3,3, (0..9).collect::<Vec<usize>>());
-//! 
+//!
 //! // Manually create our slice - [[4,5],[7,8]].
 //! let mat_slice = MatrixSlice::from_matrix(&a, [1,1], 2, 2);
 //!
@@ -413,7 +413,7 @@ mod tests {
 
     #[test]
     fn reslice() {
-        let mut a = Matrix::new(4,4, (0..16).collect());
+        let mut a = Matrix::new(4,4, (0..16).collect::<Vec<_>>());
         let b = MatrixSlice::from_matrix(&a, [1,1], 3, 3);
         {
             let c = b.reslice([0,1], 2, 2);

--- a/rusty-machine/src/linalg/vector.rs
+++ b/rusty-machine/src/linalg/vector.rs
@@ -30,13 +30,13 @@ impl<T> Vector<T> {
     ///
     /// let vec = Vector::new(vec![1.0,2.0,3.0,4.0]);
     /// ```
-    pub fn new(data: Vec<T>) -> Vector<T> {
-
-        let size = data.len();
+    pub fn new<U: Into<Vec<T>>>(data: U) -> Vector<T> {
+        let our_data = data.into();
+        let size = our_data.len();
 
         Vector {
             size: size,
-            data: data,
+            data: our_data,
         }
     }
 
@@ -607,7 +607,7 @@ impl<'a, T: Neg<Output = T> + Copy> Neg for &'a Vector<T> {
     type Output = Vector<T>;
 
     fn neg(self) -> Vector<T> {
-        let new_data = self.data.iter().map(|v| -*v).collect();
+        let new_data = self.data.iter().map(|v| -*v).collect::<Vec<_>>();
 
         Vector::new(new_data)
     }
@@ -670,6 +670,15 @@ mod tests {
         for i in 0..12 {
             assert_eq!(a[i], 1.0);
         }
+    }
+
+    #[test]
+    fn create_vector_new_from_slice() {
+        let data_vec: Vec<u32> = vec![1, 2, 3];
+        let data_slice: &[u32] = &data_vec[..];
+        let from_vec = Vector::new(data_vec.clone());
+        let from_slice = Vector::new(data_slice);
+        assert_eq!(from_vec, from_slice);
     }
 
     #[test]
@@ -905,6 +914,5 @@ mod tests {
 
         assert_eq!(b, (1. + 4. + 9. + 16. + 25. + 36. as f32).sqrt());
     }
-
 
 }


### PR DESCRIPTION
Arguments in favor:
  * Flexibility! You have the option of passing a slice (or anything else that implements `Into<Vec<T>>`) and letting `new` allocate its own vector.

Arguments against:
  * type inference doesn't work as well: notice how this commit had to add several turbofish operators to tests.
    * rebuttal: actual users mostly aren't going to be getting their data from `.collect()`, right?
