### PR TITLE
Implementing OpAssign overloading and tests

### DIFF
--- a/rusty-machine/src/linalg/matrix/impl_ops.rs
+++ b/rusty-machine/src/linalg/matrix/impl_ops.rs
@@ -1233,7 +1233,7 @@ mod tests {
         let res_data = vec![0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5];
         let mut a = Matrix::new(3, 3, a_data.clone());
 
-        a /= 2f32;
+        a /= &2f32;
         assert_eq!(a.into_vec(), res_data.clone());
 
         let mut a = Matrix::new(3, 3, a_data.clone());
@@ -1247,7 +1247,7 @@ mod tests {
         let res_data = vec![2f32, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0];
         let mut a = Matrix::new(3, 3, a_data.clone());
 
-        a *= 2f32;
+        a *= &2f32;
         assert_eq!(a.into_vec(), res_data.clone());
 
         let mut a = Matrix::new(3, 3, a_data.clone());
@@ -1366,7 +1366,7 @@ mod tests {
         let mut a = Matrix::new(3, 3, a_data.clone());
         let mut a_slice = MatrixSliceMut::from_matrix(&mut a, [0,0], 3, 3);
 
-        a_slice /= 2f32;
+        a_slice /= &2f32;
         assert_eq!(a.into_vec(), res_data.clone());
 
         let mut a = Matrix::new(3, 3, a_data.clone());
@@ -1383,7 +1383,7 @@ mod tests {
         let mut a = Matrix::new(3, 3, a_data.clone());
         let mut a_slice = MatrixSliceMut::from_matrix(&mut a, [0,0], 3, 3);
 
-        a_slice *= 2f32;
+        a_slice *= &2f32;
         assert_eq!(a.into_vec(), res_data.clone());
 
         let mut a = Matrix::new(3, 3, a_data.clone());

--- a/rusty-machine/src/linalg/matrix/impl_ops.rs
+++ b/rusty-machine/src/linalg/matrix/impl_ops.rs
@@ -7,6 +7,7 @@ use super::super::utils;
 use super::super::vector::Vector;
 
 use std::ops::{Mul, Add, Div, Sub, Index, IndexMut, Neg};
+use std::ops::{MulAssign, AddAssign, SubAssign, DivAssign};
 use libnum::Zero;
 
 
@@ -41,16 +42,13 @@ impl_index!(MatrixSliceMut, "mutable matrix slice.");
 ///
 /// Takes row index first then column.
 impl<T> IndexMut<[usize; 2]> for MatrixSliceMut<T> {
-
     fn index_mut(&mut self, idx: [usize; 2]) -> &mut T {
         assert!(idx[0] < self.rows,
                 "Row index is greater than row dimension.");
         assert!(idx[1] < self.cols,
                 "Column index is greater than column dimension.");
 
-        unsafe {
-            &mut *(self.ptr.offset((idx[0] * self.row_stride + idx[1]) as isize))
-        }
+        unsafe { &mut *(self.ptr.offset((idx[0] * self.row_stride + idx[1]) as isize)) }
     }
 }
 
@@ -58,7 +56,6 @@ impl<T> IndexMut<[usize; 2]> for MatrixSliceMut<T> {
 ///
 /// Takes row index first then column.
 impl<T> IndexMut<[usize; 2]> for Matrix<T> {
-
     fn index_mut(&mut self, idx: [usize; 2]) -> &mut T {
         assert!(idx[0] < self.rows,
                 "Row index is greater than row dimension.");
@@ -214,7 +211,7 @@ impl<T: Copy + Zero + Mul<T, Output = T> + Add<T, Output = T>> Mul<Vector<T>> fo
 }
 
 /// Multiplies matrix by vector.
-impl <'a, T: Copy + Zero + Mul<T, Output=T> + Add<T, Output=T>> Mul<Vector<T>> for &'a Matrix<T> {
+impl<'a, T: Copy + Zero + Mul<T, Output = T> + Add<T, Output = T>> Mul<Vector<T>> for &'a Matrix<T> {
     type Output = Vector<T>;
 
     fn mul(self, m: Vector<T>) -> Vector<T> {
@@ -223,7 +220,7 @@ impl <'a, T: Copy + Zero + Mul<T, Output=T> + Add<T, Output=T>> Mul<Vector<T>> f
 }
 
 /// Multiplies matrix by vector.
-impl <'a, T: Copy + Zero + Mul<T, Output=T> + Add<T, Output=T>> Mul<&'a Vector<T>> for Matrix<T> {
+impl<'a, T: Copy + Zero + Mul<T, Output = T> + Add<T, Output = T>> Mul<&'a Vector<T>> for Matrix<T> {
     type Output = Vector<T>;
 
     fn mul(self, m: &Vector<T>) -> Vector<T> {
@@ -513,6 +510,134 @@ impl<'a, 'b, T: Copy + $trt<T, Output=T>> $trt<&'b Matrix<T>> for &'a Matrix<T> 
 
 impl_bin_op_mat!(Add, add, "addition");
 impl_bin_op_mat!(Sub, sub, "subtraction");
+
+macro_rules! impl_op_assign_mat_scalar (
+    ($assign_trt:ident, $trt:ident, $op:ident, $op_assign:ident, $doc:expr) => (
+
+/// Performs
+#[doc=$doc]
+/// assignment between a matrix and a scalar.
+impl<T : Copy + $trt<T, Output=T>> $assign_trt<T> for Matrix<T> {
+    fn $op_assign(&mut self, _rhs: T) {
+        for x in self.data.iter_mut() {
+            *x = (*x).$op(_rhs)
+        }
+    }
+}
+
+/// Performs
+#[doc=$doc]
+/// assignment between a matrix and a scalar.
+impl<'a, T : Copy + $trt<T, Output=T>> $assign_trt<&'a T> for Matrix<T> {
+    fn $op_assign(&mut self, _rhs: &T) {
+        for x in self.data.iter_mut() {
+            *x = (*x).$op(*_rhs)
+        }
+    }
+}
+    );
+);
+
+impl_op_assign_mat_scalar!(AddAssign, Add, add, add_assign, "addition");
+impl_op_assign_mat_scalar!(SubAssign, Sub, sub, sub_assign, "subtraction");
+impl_op_assign_mat_scalar!(DivAssign, Div, div, div_assign, "division");
+impl_op_assign_mat_scalar!(MulAssign, Mul, mul, mul_assign, "multiplication");
+
+macro_rules! impl_op_assign_mat (
+    ($assign_trt:ident, $trt:ident, $op:ident, $op_assign:ident, $doc:expr) => (
+
+/// Performs elementwise
+#[doc=$doc]
+/// assignment between two matrices.
+impl<T : Copy + $trt<T, Output=T>> $assign_trt<Matrix<T>> for Matrix<T> {
+    fn $op_assign(&mut self, _rhs: Matrix<T>) {
+        utils::in_place_vec_bin_op(&mut self.data, &_rhs.data, |x, &y| {*x = (*x).$op(y) });
+    }
+}
+
+/// Performs elementwise
+#[doc=$doc]
+/// assignment between two matrices.
+impl<'a, T : Copy + $trt<T, Output=T>> $assign_trt<&'a Matrix<T>> for Matrix<T> {
+    fn $op_assign(&mut self, _rhs: &Matrix<T>) {
+        utils::in_place_vec_bin_op(&mut self.data, &_rhs.data, |x, &y| {*x = (*x).$op(y) });
+    }
+}
+    );
+);
+
+impl_op_assign_mat!(AddAssign, Add, add, add_assign, "addition");
+impl_op_assign_mat!(SubAssign, Sub, sub, sub_assign, "subtraction");
+
+macro_rules! impl_op_assign_slice_scalar (
+    ($assign_trt:ident, $trt:ident, $op:ident, $op_assign:ident, $doc:expr) => (
+
+/// Performs
+#[doc=$doc]
+/// assignment between a mutable matrix slice and a scalar.
+impl<T : Copy + $trt<T, Output=T>> $assign_trt<T> for MatrixSliceMut<T> {
+    fn $op_assign(&mut self, _rhs: T) {
+        for x in self.iter_mut() {
+            *x = (*x).$op(_rhs)
+        }
+    }
+}
+
+/// Performs
+#[doc=$doc]
+/// assignment between a mutable matrix slice and a scalar.
+impl<'a, T : Copy + $trt<T, Output=T>> $assign_trt<&'a T> for MatrixSliceMut<T> {
+    fn $op_assign(&mut self, _rhs: &T) {
+        for x in self.iter_mut() {
+            *x = (*x).$op(*_rhs)
+        }
+    }
+}
+    );
+);
+
+impl_op_assign_slice_scalar!(AddAssign, Add, add, add_assign, "addition");
+impl_op_assign_slice_scalar!(SubAssign, Sub, sub, sub_assign, "subtraction");
+impl_op_assign_slice_scalar!(DivAssign, Div, div, div_assign, "division");
+impl_op_assign_slice_scalar!(MulAssign, Mul, mul, mul_assign, "multiplication");
+
+macro_rules! impl_op_assign_slice (
+    ($source_mat:ident, $target_mat:ident, $assign_trt:ident, $trt:ident, $op:ident, $op_assign:ident, $doc:expr) => (
+
+/// Performs elementwise
+#[doc=$doc]
+/// assignment between two matrices.
+impl<T : Copy + $trt<T, Output=T>> $assign_trt<$target_mat<T>> for $source_mat<T> {
+    fn $op_assign(&mut self, _rhs: $target_mat<T>) {
+        for (slice_row, target_row) in self.iter_rows_mut().zip(_rhs.iter_rows()) {
+            utils::in_place_vec_bin_op(slice_row, target_row, |x, &y| {*x = (*x).$op(y) });
+        }
+    }
+}
+
+/// Performs elementwise
+#[doc=$doc]
+/// assignment between two matrices.
+impl<'a, T : Copy + $trt<T, Output=T>> $assign_trt<&'a $target_mat<T>> for $source_mat<T> {
+    fn $op_assign(&mut self, _rhs: &$target_mat<T>) {
+        for (slice_row, target_row) in self.iter_rows_mut().zip(_rhs.iter_rows()) {
+            utils::in_place_vec_bin_op(slice_row, target_row, |x, &y| {*x = (*x).$op(y) });
+        }
+    }
+}
+    );
+);
+
+impl_op_assign_slice!(MatrixSliceMut, Matrix, AddAssign, Add, add, add_assign, "addition");
+impl_op_assign_slice!(MatrixSliceMut, Matrix, SubAssign, Sub, sub, sub_assign, "subtraction");
+impl_op_assign_slice!(MatrixSliceMut, MatrixSlice, AddAssign, Add, add, add_assign, "addition");
+impl_op_assign_slice!(MatrixSliceMut, MatrixSlice, SubAssign, Sub, sub, sub_assign, "subtraction");
+impl_op_assign_slice!(MatrixSliceMut, MatrixSliceMut, AddAssign, Add, add, add_assign, "addition");
+impl_op_assign_slice!(MatrixSliceMut, MatrixSliceMut, SubAssign, Sub, sub, sub_assign, "subtraction");
+impl_op_assign_slice!(Matrix, MatrixSlice, AddAssign, Add, add, add_assign, "addition");
+impl_op_assign_slice!(Matrix, MatrixSlice, SubAssign, Sub, sub, sub_assign, "subtraction");
+impl_op_assign_slice!(Matrix, MatrixSliceMut, AddAssign, Add, add, add_assign, "addition");
+impl_op_assign_slice!(Matrix, MatrixSliceMut, SubAssign, Sub, sub, sub_assign, "subtraction");
 
 macro_rules! impl_neg_slice (
     ($slice:ident) => (
@@ -884,13 +1009,13 @@ mod tests {
         assert_eq!(c[[2, 1]], 2.0);
     }
 
-        #[test]
+    #[test]
     fn add_slice() {
         let a = 3.0;
-        let mut b = Matrix::new(3,3, vec![2.0; 9]);
-        let c = Matrix::new(2,2, vec![1.0; 4]);
+        let mut b = Matrix::new(3, 3, vec![2.0; 9]);
+        let c = Matrix::new(2, 2, vec![1.0; 4]);
 
-        let d = MatrixSlice::from_matrix(&b, [1,1], 2, 2);
+        let d = MatrixSlice::from_matrix(&b, [1, 1], 2, 2);
 
         let m_1 = &d + a.clone();
         assert_eq!(m_1.into_vec(), vec![5.0; 4]);
@@ -902,9 +1027,9 @@ mod tests {
         assert_eq!(m_3.into_vec(), vec![3.0; 4]);
 
         let m_4 = &d + &d;
-        assert_eq!(m_4.into_vec(), vec![4.0; 4]);       
+        assert_eq!(m_4.into_vec(), vec![4.0; 4]);
 
-        let e = MatrixSliceMut::from_matrix(&mut b, [1,1], 2, 2);
+        let e = MatrixSliceMut::from_matrix(&mut b, [1, 1], 2, 2);
 
         let m_1 = &e + a.clone();
         assert_eq!(m_1.into_vec(), vec![5.0; 4]);
@@ -922,10 +1047,10 @@ mod tests {
     #[test]
     fn sub_slice() {
         let a = 3.0;
-        let b = Matrix::new(2,2, vec![1.0; 4]);
-        let mut c = Matrix::new(3,3, vec![2.0; 9]);
+        let b = Matrix::new(2, 2, vec![1.0; 4]);
+        let mut c = Matrix::new(3, 3, vec![2.0; 9]);
 
-        let d = MatrixSlice::from_matrix(&c, [1,1], 2, 2);
+        let d = MatrixSlice::from_matrix(&c, [1, 1], 2, 2);
 
         let m_1 = &d - a.clone();
         assert_eq!(m_1.into_vec(), vec![-1.0; 4]);
@@ -939,7 +1064,7 @@ mod tests {
         let m_4 = &d - &d;
         assert_eq!(m_4.into_vec(), vec![0.0; 4]);
 
-        let e = MatrixSliceMut::from_matrix(&mut c, [1,1], 2, 2);
+        let e = MatrixSliceMut::from_matrix(&mut c, [1, 1], 2, 2);
 
         let m_1 = &e - a;
         assert_eq!(m_1.into_vec(), vec![-1.0; 4]);
@@ -958,14 +1083,14 @@ mod tests {
     fn div_slice() {
         let a = 3.0;
 
-        let mut b = Matrix::new(3,3, vec![2.0; 9]);
+        let mut b = Matrix::new(3, 3, vec![2.0; 9]);
 
-        let c = MatrixSlice::from_matrix(&b, [1,1], 2, 2);
+        let c = MatrixSlice::from_matrix(&b, [1, 1], 2, 2);
 
         let m = c / a;
         assert_eq!(m.into_vec(), vec![2.0/3.0 ;4]);
 
-        let d = MatrixSliceMut::from_matrix(&mut b, [1,1], 2, 2);
+        let d = MatrixSliceMut::from_matrix(&mut b, [1, 1], 2, 2);
 
         let m = d / a;
         assert_eq!(m.into_vec(), vec![2.0/3.0 ;4]);
@@ -973,16 +1098,16 @@ mod tests {
 
     #[test]
     fn neg_slice() {
-        let b = Matrix::new(3,3, vec![2.0; 9]);
+        let b = Matrix::new(3, 3, vec![2.0; 9]);
 
-        let c = MatrixSlice::from_matrix(&b, [1,1], 2, 2);
+        let c = MatrixSlice::from_matrix(&b, [1, 1], 2, 2);
 
         let m = -c;
         assert_eq!(m.into_vec(), vec![-2.0;4]);
 
-        let mut b = Matrix::new(3,3, vec![2.0; 9]);
+        let mut b = Matrix::new(3, 3, vec![2.0; 9]);
 
-        let c = MatrixSliceMut::from_matrix(&mut b, [1,1], 2, 2);
+        let c = MatrixSliceMut::from_matrix(&mut b, [1, 1], 2, 2);
 
         let m = -c;
         assert_eq!(m.into_vec(), vec![-2.0;4]);
@@ -990,27 +1115,281 @@ mod tests {
 
     #[test]
     fn index_slice() {
-        let mut b = Matrix::new(3,3, (0..9).collect());
+        let mut b = Matrix::new(3, 3, (0..9).collect());
 
-        let c = MatrixSlice::from_matrix(&b, [1,1], 2, 2);
+        let c = MatrixSlice::from_matrix(&b, [1, 1], 2, 2);
+
+        assert_eq!(c[[0, 0]], 4);
+        assert_eq!(c[[0, 1]], 5);
+        assert_eq!(c[[1, 0]], 7);
+        assert_eq!(c[[1, 1]], 8);
+
+        let mut c = MatrixSliceMut::from_matrix(&mut b, [1, 1], 2, 2);
+
+        assert_eq!(c[[0, 0]], 4);
+        assert_eq!(c[[0, 1]], 5);
+        assert_eq!(c[[1, 0]], 7);
+        assert_eq!(c[[1, 1]], 8);
+
+        c[[0, 0]] = 9;
+
+        assert_eq!(c[[0, 0]], 9);
+        assert_eq!(c[[0, 1]], 5);
+        assert_eq!(c[[1, 0]], 7);
+        assert_eq!(c[[1, 1]], 8);
+    }
+
+    #[test]
+    fn matrix_add_assign() {
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<_>>());
+
+        a += &2;
+        assert_eq!(a.into_vec(), (2..11).collect::<Vec<_>>());
+
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<_>>());
+
+        a += 2;
+        assert_eq!(a.into_vec(), (2..11).collect::<Vec<_>>());
+
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<_>>());
+        let b = Matrix::new(3, 3, (0..9).collect::<Vec<_>>());
+
+        a += &b;
+        assert_eq!(a.into_vec(), (0..9).map(|x| 2 * x).collect::<Vec<_>>());
+
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<_>>());
+
+        a += b;
+        assert_eq!(a.into_vec(), (0..9).map(|x| 2 * x).collect::<Vec<_>>());
+
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<_>>());
+        let mut b = Matrix::new(4, 4, (0..16).collect::<Vec<_>>());
+        let c = MatrixSlice::from_matrix(&b, [0, 0], 3, 3);
+
+        a += &c;
+        assert_eq!(a.into_vec(), vec![0, 2, 4, 7, 9, 11, 14, 16, 18]);
+
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<_>>());
+        a += c;
+        assert_eq!(a.into_vec(), vec![0, 2, 4, 7, 9, 11, 14, 16, 18]);
+
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<_>>());
+        let c = MatrixSliceMut::from_matrix(&mut b, [0, 0], 3, 3);
+        a += &c;
+        assert_eq!(a.into_vec(), vec![0, 2, 4, 7, 9, 11, 14, 16, 18]);
+
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<_>>());
+        a += c;
+        assert_eq!(a.into_vec(), vec![0, 2, 4, 7, 9, 11, 14, 16, 18]);
+
+    }
+
+    #[test]
+    fn matrix_sub_assign() {
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<i32>>());
         
-        assert_eq!(c[[0,0]], 4);
-        assert_eq!(c[[0,1]], 5);
-        assert_eq!(c[[1,0]], 7);
-        assert_eq!(c[[1,1]], 8);
+        a -= &2;
+        assert_eq!(a.into_vec(), (-2..7).collect::<Vec<_>>());
 
-        let mut c = MatrixSliceMut::from_matrix(&mut b, [1,1], 2, 2);
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<i32>>());
+        a -= 2;
+        assert_eq!(a.into_vec(), (-2..7).collect::<Vec<_>>());
+
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<_>>());
+        let b = Matrix::new(3, 3, (0..9).collect::<Vec<_>>());
+
+        a -= &b;
+        assert_eq!(a.into_vec(), vec![0; 9]);
+
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<_>>());
+
+        a -= b;
+        assert_eq!(a.into_vec(), vec![0; 9]);
+
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<_>>());
+        let mut b = Matrix::new(4, 4, (0..16).collect::<Vec<_>>());
+        let c = MatrixSlice::from_matrix(&b, [0, 0], 3, 3);
+
+        a -= &c;
+        assert_eq!(a.into_vec(), vec![0, 0, 0, -1, -1, -1, -2, -2, -2]);
+
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<_>>());
+        a -= c;
+        assert_eq!(a.into_vec(), vec![0, 0, 0, -1, -1, -1, -2, -2, -2]);
+
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<_>>());
+        let c = MatrixSliceMut::from_matrix(&mut b, [0, 0], 3, 3);
+        a -= &c;
+        assert_eq!(a.into_vec(), vec![0, 0, 0, -1, -1, -1, -2, -2, -2]);
+
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<_>>());
+        a -= c;
+        assert_eq!(a.into_vec(), vec![0, 0, 0, -1, -1, -1, -2, -2, -2]);
+    }
+
+    #[test]
+    fn matrix_div_assign() {
+        let a_data = vec![1f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
+        let res_data = vec![0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5];
+        let mut a = Matrix::new(3, 3, a_data.clone());
+
+        a /= 2f32;
+        assert_eq!(a.into_vec(), res_data.clone());
+
+        let mut a = Matrix::new(3, 3, a_data.clone());
+        a /= 2f32;
+        assert_eq!(a.into_vec(), res_data.clone());
+    }
+
+    #[test]
+    fn matrix_mul_assign() {
+        let a_data = vec![1f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
+        let res_data = vec![2f32, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0];
+        let mut a = Matrix::new(3, 3, a_data.clone());
+
+        a *= 2f32;
+        assert_eq!(a.into_vec(), res_data.clone());
+
+        let mut a = Matrix::new(3, 3, a_data.clone());
+        a *= 2f32;
+        assert_eq!(a.into_vec(), res_data.clone());
+    }
+
+        #[test]
+    fn slice_add_assign() {
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<i32>>());
+        let mut a_slice = MatrixSliceMut::from_matrix(&mut a, [0,0], 3, 3);
+
+        a_slice += &2;
+        assert_eq!(a.into_vec(), (2..11).collect::<Vec<_>>());
+
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<i32>>());
+        let mut a_slice = MatrixSliceMut::from_matrix(&mut a, [0,0], 3, 3);
+
+        a_slice += 2;
+        assert_eq!(a.into_vec(), (2..11).collect::<Vec<_>>());
+
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<i32>>());
+        let mut a_slice = MatrixSliceMut::from_matrix(&mut a, [0,0], 3, 3);
+        let b = Matrix::new(3, 3, (0..9).collect::<Vec<_>>());
+
+        a_slice += &b;
+        assert_eq!(a.into_vec(), (0..9).map(|x| 2 * x).collect::<Vec<_>>());
+
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<i32>>());
+        let mut a_slice = MatrixSliceMut::from_matrix(&mut a, [0,0], 3, 3);
+
+        a_slice += b;
+        assert_eq!(a.into_vec(), (0..9).map(|x| 2 * x).collect::<Vec<_>>());
+
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<i32>>());
+        let mut a_slice = MatrixSliceMut::from_matrix(&mut a, [0,0], 3, 3);
+        let mut b = Matrix::new(4, 4, (0..16).collect::<Vec<_>>());
+        let c = MatrixSlice::from_matrix(&b, [0, 0], 3, 3);
+
+        a_slice += &c;
+        assert_eq!(a.into_vec(), vec![0, 2, 4, 7, 9, 11, 14, 16, 18]);
+
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<i32>>());
+        let mut a_slice = MatrixSliceMut::from_matrix(&mut a, [0,0], 3, 3);
+        a_slice += c;
+        assert_eq!(a.into_vec(), vec![0, 2, 4, 7, 9, 11, 14, 16, 18]);
+
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<i32>>());
+        let mut a_slice = MatrixSliceMut::from_matrix(&mut a, [0,0], 3, 3);
+        let c = MatrixSliceMut::from_matrix(&mut b, [0, 0], 3, 3);
+        a_slice += &c;
+        assert_eq!(a.into_vec(), vec![0, 2, 4, 7, 9, 11, 14, 16, 18]);
+
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<i32>>());
+        let mut a_slice = MatrixSliceMut::from_matrix(&mut a, [0,0], 3, 3);
+        a_slice += c;
+        assert_eq!(a.into_vec(), vec![0, 2, 4, 7, 9, 11, 14, 16, 18]);
+
+    }
+
+    #[test]
+    fn slice_sub_assign() {
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<i32>>());
+        let mut a_slice = MatrixSliceMut::from_matrix(&mut a, [0,0], 3, 3);
         
-        assert_eq!(c[[0,0]], 4);
-        assert_eq!(c[[0,1]], 5);
-        assert_eq!(c[[1,0]], 7);
-        assert_eq!(c[[1,1]], 8);
+        a_slice -= &2;
+        assert_eq!(a.into_vec(), (-2..7).collect::<Vec<_>>());
 
-        c[[0,0]] = 9;
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<i32>>());
+        let mut a_slice = MatrixSliceMut::from_matrix(&mut a, [0,0], 3, 3);
+        a_slice -= 2;
+        assert_eq!(a.into_vec(), (-2..7).collect::<Vec<_>>());
 
-        assert_eq!(c[[0,0]], 9);
-        assert_eq!(c[[0,1]], 5);
-        assert_eq!(c[[1,0]], 7);
-        assert_eq!(c[[1,1]], 8);
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<i32>>());
+        let mut a_slice = MatrixSliceMut::from_matrix(&mut a, [0,0], 3, 3);
+        let b = Matrix::new(3, 3, (0..9).collect::<Vec<_>>());
+
+        a_slice -= &b;
+        assert_eq!(a.into_vec(), vec![0; 9]);
+
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<i32>>());
+        let mut a_slice = MatrixSliceMut::from_matrix(&mut a, [0,0], 3, 3);
+
+        a_slice -= b;
+        assert_eq!(a.into_vec(), vec![0; 9]);
+
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<i32>>());
+        let mut a_slice = MatrixSliceMut::from_matrix(&mut a, [0,0], 3, 3);
+        let mut b = Matrix::new(4, 4, (0..16).collect::<Vec<_>>());
+        let c = MatrixSlice::from_matrix(&b, [0, 0], 3, 3);
+
+        a_slice -= &c;
+        assert_eq!(a.into_vec(), vec![0, 0, 0, -1, -1, -1, -2, -2, -2]);
+
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<i32>>());
+        let mut a_slice = MatrixSliceMut::from_matrix(&mut a, [0,0], 3, 3);
+        a_slice -= c;
+        assert_eq!(a.into_vec(), vec![0, 0, 0, -1, -1, -1, -2, -2, -2]);
+
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<i32>>());
+        let mut a_slice = MatrixSliceMut::from_matrix(&mut a, [0,0], 3, 3);
+        let c = MatrixSliceMut::from_matrix(&mut b, [0, 0], 3, 3);
+        a_slice -= &c;
+        assert_eq!(a.into_vec(), vec![0, 0, 0, -1, -1, -1, -2, -2, -2]);
+
+        let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<i32>>());
+        let mut a_slice = MatrixSliceMut::from_matrix(&mut a, [0,0], 3, 3);
+        a_slice -= c;
+        assert_eq!(a.into_vec(), vec![0, 0, 0, -1, -1, -1, -2, -2, -2]);
+    }
+
+    #[test]
+    fn slice_div_assign() {
+        let a_data = vec![1f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
+        let res_data = vec![0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5];
+        let mut a = Matrix::new(3, 3, a_data.clone());
+        let mut a_slice = MatrixSliceMut::from_matrix(&mut a, [0,0], 3, 3);
+
+        a_slice /= 2f32;
+        assert_eq!(a.into_vec(), res_data.clone());
+
+        let mut a = Matrix::new(3, 3, a_data.clone());
+        let mut a_slice = MatrixSliceMut::from_matrix(&mut a, [0,0], 3, 3);
+
+        a_slice /= 2f32;
+        assert_eq!(a.into_vec(), res_data.clone());
+    }
+
+    #[test]
+    fn slice_mul_assign() {
+        let a_data = vec![1f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
+        let res_data = vec![2f32, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0];
+        let mut a = Matrix::new(3, 3, a_data.clone());
+        let mut a_slice = MatrixSliceMut::from_matrix(&mut a, [0,0], 3, 3);
+
+        a_slice *= 2f32;
+        assert_eq!(a.into_vec(), res_data.clone());
+
+        let mut a = Matrix::new(3, 3, a_data.clone());
+        let mut a_slice = MatrixSliceMut::from_matrix(&mut a, [0,0], 3, 3);
+
+        a_slice *= 2f32;
+        assert_eq!(a.into_vec(), res_data.clone());
     }
 }


### PR DESCRIPTION
This resolves issue #42 .

This PR introduces OpAssign for:

- `Matrix`.op_assign(scalar)
- `MatrixSliceMut`.op_assign(scalar)
- `Matrix` += OR -= `Matrix`
- `Matrix` += OR -= `MatrixSlice`
- `Matrix` += OR -= `MatrixSliceMut`
- `MatrixSliceMut` += OR -= `Matrix`
- `MatrixSliceMut` += OR -= `MatrixSlice`
- `MatrixSliceMut` += OR -= `MatrixSliceMut`

The macros can probably be cleaned up. Additionally the tests could probably use macros to make them shorter...