### PR TITLE
clean up compiler warnings

### DIFF
--- a/rusty-machine/src/linalg/matrix/impl_ops.rs
+++ b/rusty-machine/src/linalg/matrix/impl_ops.rs
@@ -1187,7 +1187,7 @@ mod tests {
     #[test]
     fn matrix_sub_assign() {
         let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<i32>>());
-        
+
         a -= &2;
         assert_eq!(a.into_vec(), (-2..7).collect::<Vec<_>>());
 
@@ -1255,7 +1255,8 @@ mod tests {
         assert_eq!(a.into_vec(), res_data.clone());
     }
 
-        #[test]
+    #[test]
+    #[allow(unused_assignments, unused_variables)]
     fn slice_add_assign() {
         let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<i32>>());
         let mut a_slice = MatrixSliceMut::from_matrix(&mut a, [0,0], 3, 3);
@@ -1309,10 +1310,11 @@ mod tests {
     }
 
     #[test]
+    #[allow(unused_assignments, unused_variables)]
     fn slice_sub_assign() {
         let mut a = Matrix::new(3, 3, (0..9).collect::<Vec<i32>>());
         let mut a_slice = MatrixSliceMut::from_matrix(&mut a, [0,0], 3, 3);
-        
+
         a_slice -= &2;
         assert_eq!(a.into_vec(), (-2..7).collect::<Vec<_>>());
 
@@ -1360,6 +1362,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(unused_assignments, unused_variables)]
     fn slice_div_assign() {
         let a_data = vec![1f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
         let res_data = vec![0.5, 1.0, 1.5, 2.0, 2.5, 3.0, 3.5, 4.0, 4.5];
@@ -1377,6 +1380,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(unused_assignments, unused_variables)]
     fn slice_mul_assign() {
         let a_data = vec![1f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0];
         let res_data = vec![2f32, 4.0, 6.0, 8.0, 10.0, 12.0, 14.0, 16.0, 18.0];

--- a/rusty-machine/tests/learning/gp.rs
+++ b/rusty-machine/tests/learning/gp.rs
@@ -15,5 +15,5 @@ fn test_default_gp() {
 
 	let test_inputs = Matrix::new(5,1,vec![2.3,4.4,5.1,6.2,7.1]);
 
-	let outputs = gp.predict(&test_inputs);
+	let _outputs = gp.predict(&test_inputs);
 }


### PR DESCRIPTION
The augmented-assignment tests in particular generated a lot of
unused-variable and unused-assignment warnings, which are undesirable
not only on æsthetic developer-experience grounds but, more importantly,
because genuinely useful warnings inadvertently set off by future
development efforts could get lost in the noise. Typically one would
indicate an intentionally-unused variable by choosing an identifier
starting with an underscore, but in the case of the augmented-assignment
tests, the `allow`-directive attributes seem more appropriate: the
`a_slice` variables weren't _really_ unused; it's just that `rustc`
isn't smart enough to notice that they're views into an underlying
matrix which is being used.