### PR TITLE
Regularization

### DIFF
--- a/rusty-machine/src/learning/nnet.rs
+++ b/rusty-machine/src/learning/nnet.rs
@@ -327,12 +327,11 @@ impl<'a, T: Criterion> BaseNeuralNet<'a, T> {
 
             // Add the regularized gradient
             if self.criterion.is_regularized() {
-                for i in 0..self.layer_sizes.len() - 1 {
-                    let non_bias_weights = self.get_non_bias_weights(weights, i);
-                    let zeros = Matrix::zeros(non_bias_weights.rows(), 1);
+                let layer = self.layer_sizes.len() - 2 - l;
+                let non_bias_weights = self.get_non_bias_weights(weights, layer);
+                let zeros = Matrix::zeros(non_bias_weights.rows(), 1);
 
-                    g += zeros.hcat(&self.criterion.reg_cost_grad(non_bias_weights));
-                }
+                g += zeros.hcat(&self.criterion.reg_cost_grad(non_bias_weights));
             }
 
             capacity += g.cols() * g.rows();

--- a/rusty-machine/src/learning/toolkit/regularization.rs
+++ b/rusty-machine/src/learning/toolkit/regularization.rs
@@ -1,27 +1,72 @@
 use linalg::Metric;
 use linalg::matrix::{Matrix, MatrixSlice};
-use libnum::Float;
+use linalg::matrix::slice::BaseSlice;
+use linalg::utils;
+use libnum::{FromPrimitive, Float};
 
 /// Model Regularization
 #[derive(Debug, Clone, Copy)]
 pub enum Regularization<T: Float> {
+    /// L1 Regularization
+    L1(T),
     /// L2 Regularization
     L2(T),
+    /// Elastic Net Regularization
+    ElasticNet(T),
+    /// No Regularization
+    None,
 }
 
-impl<T : Float> Regularization<T> {
+impl<T: Float + FromPrimitive> Regularization<T> {
+    /// Compute the regularization addition to the cost.
+    pub fn reg_cost(&self, mat: MatrixSlice<T>) -> T {
+        match self {
+            &Regularization::L1(x) => Self::l1_reg_cost(&mat, x),
+            &Regularization::L2(x) => Self::l2_reg_cost(&mat, x),
+            &Regularization::ElasticNet(x) => {
+                Self::l1_reg_cost(&mat, x) + Self::l2_reg_cost(&mat, x)
+            }
+            &Regularization::None => T::zero(),
+        }
+    }
 
-	/// Compute the regularization addition to the cost.
-	pub fn reg_cost(&self, mat: MatrixSlice<T>) -> T {
-		match self {
-			&Regularization::L2(x) => mat.norm() * x / (T::one() + T::one()),
-		}
-	}
+    /// Compute the regularization addition to the gradient.
+    pub fn reg_grad(&self, mat: MatrixSlice<T>) -> Matrix<T> {
+        match self {
+            &Regularization::L1(x) => Self::l1_reg_grad(&mat, x),
+            &Regularization::L2(x) => Self::l2_reg_grad(&mat, x),
+            &Regularization::ElasticNet(x) => {
+                Self::l1_reg_grad(&mat, x) + Self::l2_reg_grad(&mat, x)
+            }
+            &Regularization::None => Matrix::zeros(mat.rows(), mat.cols()),
+        }
+    }
 
-	/// Compute the regularization addition to the gradient.
-	pub fn reg_grad(&self, mat: MatrixSlice<T>) -> Matrix<T> {
-		match self {
-			&Regularization::L2(x) => mat * x,
-		}
-	}
-} 
+    fn l1_reg_cost(mat: &MatrixSlice<T>, x: T) -> T {
+        let l1_norm = mat.iter_rows()
+                         .fold(T::zero(), |acc, row| acc + utils::unrolled_sum(row));
+        l1_norm * x / ((T::one() + T::one()) * FromPrimitive::from_usize(mat.rows()).unwrap())
+    }
+
+    fn l1_reg_grad(mat: &MatrixSlice<T>, x: T) -> Matrix<T> {
+        let m_2 = (T::one() + T::one()) * FromPrimitive::from_usize(mat.rows()).unwrap();
+        let out_mat_data = mat.iter()
+                              .map(|y| {
+                                  if y.is_sign_negative() {
+                                      -x / m_2
+                                  } else {
+                                      x / m_2
+                                  }
+                              })
+                              .collect::<Vec<_>>();
+        Matrix::new(mat.rows(), mat.cols(), out_mat_data)
+    }
+
+    fn l2_reg_cost(mat: &MatrixSlice<T>, x: T) -> T {
+        mat.norm() * x / ((T::one() + T::one()) * FromPrimitive::from_usize(mat.rows()).unwrap())
+    }
+
+    fn l2_reg_grad(mat: &MatrixSlice<T>, x: T) -> Matrix<T> {
+        mat * (x / FromPrimitive::from_usize(mat.rows()).unwrap())
+    }
+}

--- a/rusty-machine/src/learning/toolkit/regularization.rs
+++ b/rusty-machine/src/learning/toolkit/regularization.rs
@@ -1,0 +1,27 @@
+use linalg::Metric;
+use linalg::matrix::{Matrix, MatrixSlice};
+use libnum::Float;
+
+/// Model Regularization
+#[derive(Debug, Clone, Copy)]
+pub enum Regularization<T: Float> {
+    /// L2 Regularization
+    L2(T),
+}
+
+impl<T : Float> Regularization<T> {
+
+	/// Compute the regularization addition to the cost.
+	pub fn reg_cost(&self, mat: MatrixSlice<T>) -> T {
+		match self {
+			&Regularization::L2(x) => mat.norm() * x / (T::one() + T::one()),
+		}
+	}
+
+	/// Compute the regularization addition to the gradient.
+	pub fn reg_grad(&self, mat: MatrixSlice<T>) -> Matrix<T> {
+		match self {
+			&Regularization::L2(x) => mat * x,
+		}
+	}
+} 

--- a/rusty-machine/src/learning/toolkit/regularization.rs
+++ b/rusty-machine/src/learning/toolkit/regularization.rs
@@ -11,8 +11,8 @@ pub enum Regularization<T: Float> {
     L1(T),
     /// L2 Regularization
     L2(T),
-    /// Elastic Net Regularization
-    ElasticNet(T),
+    /// Elastic Net Regularization (L1 and L2)
+    ElasticNet(T, T),
     /// No Regularization
     None,
 }
@@ -23,8 +23,8 @@ impl<T: Float + FromPrimitive> Regularization<T> {
         match self {
             &Regularization::L1(x) => Self::l1_reg_cost(&mat, x),
             &Regularization::L2(x) => Self::l2_reg_cost(&mat, x),
-            &Regularization::ElasticNet(x) => {
-                Self::l1_reg_cost(&mat, x) + Self::l2_reg_cost(&mat, x)
+            &Regularization::ElasticNet(x, y) => {
+                Self::l1_reg_cost(&mat, x) + Self::l2_reg_cost(&mat, y)
             }
             &Regularization::None => T::zero(),
         }
@@ -35,8 +35,8 @@ impl<T: Float + FromPrimitive> Regularization<T> {
         match self {
             &Regularization::L1(x) => Self::l1_reg_grad(&mat, x),
             &Regularization::L2(x) => Self::l2_reg_grad(&mat, x),
-            &Regularization::ElasticNet(x) => {
-                Self::l1_reg_grad(&mat, x) + Self::l2_reg_grad(&mat, x)
+            &Regularization::ElasticNet(x, y) => {
+                Self::l1_reg_grad(&mat, x) + Self::l2_reg_grad(&mat, y)
             }
             &Regularization::None => Matrix::zeros(mat.rows(), mat.cols()),
         }

--- a/rusty-machine/src/lib.rs
+++ b/rusty-machine/src/lib.rs
@@ -191,6 +191,7 @@ pub mod learning {
         pub mod kernel;
         pub mod cost_fn;
         pub mod rand_utils;
+        pub mod regularization;
     }
 }
 

--- a/rusty-machine/src/linalg/matrix/mod.rs
+++ b/rusty-machine/src/linalg/matrix/mod.rs
@@ -1115,8 +1115,58 @@ impl<T: Float> Metric<T> for Matrix<T> {
     /// assert_eq!(c, 5.0);
     /// ```
     fn norm(&self) -> T {
-        let s = utils::dot(&self.data[..], &self.data[..]);
+        let s = utils::dot(&self.data, &self.data);
 
+        s.sqrt()
+    }
+}
+
+impl<T: Float> Metric<T> for MatrixSlice<T> {
+    /// Compute euclidean norm for matrix.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rusty_machine::linalg::matrix::{Matrix, MatrixSlice};
+    /// use rusty_machine::linalg::Metric;
+    ///
+    /// let a = Matrix::new(2,1, vec![3.0,4.0]);
+    /// let b = MatrixSlice::from_matrix(&a, [0,0], 2, 1);
+    /// let c = b.norm();
+    ///
+    /// assert_eq!(c, 5.0);
+    /// ```
+    fn norm(&self) -> T {
+        let mut s = T::zero();
+
+        for row in self.iter_rows() {
+            s = s + utils::dot(row, row);
+        }
+        s.sqrt()
+    }
+}
+
+impl<T: Float> Metric<T> for MatrixSliceMut<T> {
+    /// Compute euclidean norm for matrix.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use rusty_machine::linalg::matrix::{Matrix, MatrixSliceMut};
+    /// use rusty_machine::linalg::Metric;
+    ///
+    /// let mut a = Matrix::new(2,1, vec![3.0,4.0]);
+    /// let b = MatrixSliceMut::from_matrix(&mut a, [0,0], 2, 1);
+    /// let c = b.norm();
+    ///
+    /// assert_eq!(c, 5.0);
+    /// ```
+    fn norm(&self) -> T {
+        let mut s = T::zero();
+
+        for row in self.iter_rows() {
+            s = s + utils::dot(row, row);
+        }
         s.sqrt()
     }
 }

--- a/rusty-machine/src/linalg/matrix/slice.rs
+++ b/rusty-machine/src/linalg/matrix/slice.rs
@@ -209,12 +209,7 @@ impl<T> MatrixSlice<T> {
 impl<T: Copy> MatrixSlice<T> {
     /// Convert the matrix slice into a new Matrix.
     pub fn into_matrix(self) -> Matrix<T> {
-        let slice_data = self.iter().map(|v| *v).collect::<Vec<T>>();
-        Matrix {
-            rows: self.rows,
-            cols: self.cols,
-            data: slice_data,
-        }
+        self.iter_rows().collect::<Matrix<T>>()
     }
 }
 


### PR DESCRIPTION
This resolves issue #67 .

This PR includes a new `regularization` module. The module provides implementations of L1, L2 and Elastic Net regularization.

The regularization is only implemented within the Neural Networks. It provides some much needed numerical stability there. The construction of the module should allow it to be easily implemented in the other modules that require.

_Note: For linear regression we can solve the L2 Regularization analytically. Other than this we should be able to add regularization easily._