### PR TITLE
Into<Matrix> and From<>-for-Matrix, for Vector and matrix slices

### DIFF
--- a/rusty-machine/src/learning/nnet.rs
+++ b/rusty-machine/src/learning/nnet.rs
@@ -29,7 +29,7 @@
 //! model.train(&inputs, &targets);
 //!
 //! let test_inputs = Matrix::new(2,3, vec![1.5,1.5,1.5,5.1,5.1,5.1]);
-//! 
+//!
 //! // And predict new output from the test inputs
 //! model.predict(&test_inputs);
 //! ```
@@ -318,7 +318,7 @@ impl<'a, T: Criterion> BaseNeuralNet<'a, T> {
                 z = ones.hcat(&z);
 
                 let g = self.criterion.grad_activ(z);
-                delta = (delta * self.get_layer_weights(weights, l).into_matrix().transpose())
+                delta = (delta * Matrix::from(self.get_layer_weights(weights, l)).transpose())
                             .elemul(&g);
 
                 let non_one_rows = &(1..delta.cols()).collect::<Vec<usize>>()[..];

--- a/rusty-machine/src/lib.rs
+++ b/rusty-machine/src/lib.rs
@@ -114,6 +114,7 @@ pub mod linalg {
     pub mod matrix;
     pub mod vector;
     pub mod utils;
+    pub mod convert;
     pub mod macros;
 }
 

--- a/rusty-machine/src/linalg/convert.rs
+++ b/rusty-machine/src/linalg/convert.rs
@@ -10,10 +10,23 @@ impl<T> From<Vector<T>> for Matrix<T> {
     }
 }
 
+macro_rules! impl_matrix_from {
+    ($slice_type:ident) => {
+        impl<'a, T: Copy> From<$slice_type<'a, T>> for Matrix<T> {
+            fn from(slice: $slice_type<'a, T>) -> Self {
+                slice.iter_rows().collect::<Matrix<T>>()
+            }
+        }
+    }
+}
+
+impl_matrix_from!(MatrixSlice);
+impl_matrix_from!(MatrixSliceMut);
+
 
 #[cfg(test)]
 mod tests {
-    use super::super::matrix::Matrix;
+    use super::super::matrix::{Matrix, MatrixSlice, MatrixSliceMut};
     use super::super::vector::Vector;
 
     #[test]
@@ -27,6 +40,23 @@ mod tests {
         let matrix_product = um.transpose() * vm;
 
         assert_eq!(dot_product, matrix_product.data()[0]);
+    }
+
+    #[test]
+    fn matrix_from_slice() {
+        let mut a = Matrix::new(3, 3, vec![2.0; 9]);
+
+        {
+            let b = MatrixSlice::from_matrix(&a, [1, 1], 2, 2);
+            let c = Matrix::from(b);
+            assert_eq!(c.rows(), 2);
+            assert_eq!(c.cols(), 2);
+        }
+
+        let d = MatrixSliceMut::from_matrix(&mut a, [1, 1], 2, 2);
+        let e = Matrix::from(d);
+        assert_eq!(e.rows(), 2);
+        assert_eq!(e.cols(), 2);
     }
 
 }

--- a/rusty-machine/src/linalg/convert.rs
+++ b/rusty-machine/src/linalg/convert.rs
@@ -1,0 +1,32 @@
+use std::convert::From;
+
+use super::matrix::{Matrix, MatrixSlice, MatrixSliceMut};
+use super::vector::Vector;
+
+
+impl<T> From<Vector<T>> for Matrix<T> {
+    fn from(vector: Vector<T>) -> Self {
+        Matrix::new(vector.size(), 1, vector.into_vec())
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::super::matrix::Matrix;
+    use super::super::vector::Vector;
+
+    #[test]
+    fn inner_product_as_matrix_multiplication() {
+        let u: Vector<f32> = Vector::new(vec![1., 2., 3.]);
+        let v: Vector<f32> = Vector::new(vec![3., 4., 5.]);
+        let dot_product = u.dot(&v);
+
+        let um: Matrix<f32> = u.into();
+        let vm: Matrix<f32> = v.into();
+        let matrix_product = um.transpose() * vm;
+
+        assert_eq!(dot_product, matrix_product.data()[0]);
+    }
+
+}


### PR DESCRIPTION
`std::convert` provides slick `From` and `Into` traits for converting between types (and implementing `From` automatically gives you `Into`); we could be making more use of them (in addition to accepting U: Into<Vec<T>> as initialization data, as seen in #53) in the following two ways—

* By implementing `From<Vector<T>>` for `Matrix<T>`, we can convert vectors to _n_-by-1 matrices, which is often a worthwhile way of thinking about them.

* We can replace our `into_matrix` methods for matrix slices with `From`/`Into`. (Although a counterargument against this is that type inference can't always infer what you mean by `my_slice.into()`, whereas `my_slice.into_matrix()` didn't have that problem. Also, if we were going to do this, one might expect us to also similarly replace the `into_vec` methods on matrices and vectors, but that turns out to be subtler than it first appears due to trait coherence rules forbidding implementation of a trait not defined in the current crate for a type not defined in the current crate.)