### PR TITLE
K means and error handling

### DIFF
--- a/rusty-machine/src/learning/error.rs
+++ b/rusty-machine/src/learning/error.rs
@@ -1,0 +1,49 @@
+//! Error handling for the learning module.
+
+use std::boxed::Box;
+use std::convert::Into;
+use std::error;
+use std::fmt;
+use std::marker::{Send, Sync};
+
+/// An error related to the learning module.
+#[derive(Debug)]
+pub struct Error {
+    kind: ErrorKind,
+    error: Box<error::Error + Send + Sync>,
+}
+
+/// Types of errors produced in the learning module.
+///
+/// List intended to grow and so you should
+/// be wary of matching against explicitly.
+#[derive(Debug)]
+pub enum ErrorKind {
+    /// The parameters used to define the model are not valid.
+    InvalidParameters,
+    /// The input data to the model is not valid.
+    InvalidData,
+}
+
+impl Error {
+    pub fn new<E>(kind: ErrorKind, error: E) -> Error
+        where E: Into<Box<error::Error + Send + Sync>>
+    {
+        Error {
+            kind: kind,
+            error: error.into(),
+        }
+    }
+}
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        self.error.description()
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        self.error.fmt(f)
+    }
+}

--- a/rusty-machine/src/learning/error.rs
+++ b/rusty-machine/src/learning/error.rs
@@ -26,6 +26,7 @@ pub enum ErrorKind {
 }
 
 impl Error {
+    /// Construct a new `Error` of a particular `ErrorKind`.
     pub fn new<E>(kind: ErrorKind, error: E) -> Error
         where E: Into<Box<error::Error + Send + Sync>>
     {
@@ -33,6 +34,11 @@ impl Error {
             kind: kind,
             error: error.into(),
         }
+    }
+
+    /// Get the kind of this `Error`.
+    pub fn kind(&self) -> &ErrorKind {
+        &self.kind
     }
 }
 

--- a/rusty-machine/src/learning/k_means.rs
+++ b/rusty-machine/src/learning/k_means.rs
@@ -207,7 +207,7 @@ impl<InitAlg: Initializer> KMeansClassifier<InitAlg> {
             let vec_i: Vec<usize> = classes.data()
                                            .iter()
                                            .filter(|&x| *x == i)
-                                           .map(|x| *x)
+                                           .cloned()
                                            .collect();
 
             let mat_i = inputs.select_rows(&vec_i);
@@ -298,7 +298,7 @@ impl Initializer for RandomPartition {
         for i in 0..k {
             let vec_i: Vec<usize> = random_assignments.iter()
                                                       .filter(|&x| *x == i)
-                                                      .map(|x| *x)
+                                                      .cloned()
                                                       .collect();
 
             let mat_i = inputs.select_rows(&vec_i);

--- a/rusty-machine/src/lib.rs
+++ b/rusty-machine/src/lib.rs
@@ -138,6 +138,8 @@ pub mod learning {
     pub mod svm;
     pub mod naive_bayes;
 
+    pub mod error;
+
     /// Trait for supervised model.
     pub trait SupModel<T,U> {
 

--- a/rusty-machine/src/lib.rs
+++ b/rusty-machine/src/lib.rs
@@ -101,6 +101,7 @@
 //! let _ = Matrix::new(2,2,vec![2.0;4]);
 //! ```
 
+#![deny(missing_docs)]
 #![warn(missing_debug_implementations)]
 
 extern crate num as libnum;

--- a/rusty-machine/tests/learning/k_means.rs
+++ b/rusty-machine/tests/learning/k_means.rs
@@ -1,11 +1,11 @@
 use rm::linalg::matrix::Matrix;
 use rm::learning::UnSupModel;
 use rm::learning::k_means::KMeansClassifier;
-use rm::learning::k_means::InitAlgorithm;
+use rm::learning::k_means::{Forgy, RandomPartition, KPlusPlus};
 
 #[test]
 fn test_model_default() {
-    let mut model = KMeansClassifier::new(3);
+    let mut model = KMeansClassifier::<KPlusPlus>::new(3);
     let inputs = Matrix::new(3, 2, vec![1.0, 2.0, 1.0, 3.0, 1.0, 4.0]);
     let targets = Matrix::new(3,2, vec![1.0, 2.0, 1.0, 3.0, 1.0, 4.0]);
 
@@ -18,11 +18,11 @@ fn test_model_default() {
 
 #[test]
 fn test_model_iter() {
-    let mut model = KMeansClassifier::new(3);
+    let mut model = KMeansClassifier::<KPlusPlus>::new(3);
     let inputs = Matrix::new(3, 2, vec![1.0, 2.0, 1.0, 3.0, 1.0, 4.0]);
     let targets = Matrix::new(3,2, vec![1.0, 2.0, 1.0, 3.0, 1.0, 4.0]);
 
-    model.iters = 1000;
+    model.set_iters(1000);
     model.train(&inputs);
 
     let outputs = model.predict(&targets);
@@ -32,11 +32,10 @@ fn test_model_iter() {
 
 #[test]
 fn test_model_forgy() {
-    let mut model = KMeansClassifier::new(3);
+    let mut model = KMeansClassifier::new_specified(3, 100, Forgy);
     let inputs = Matrix::new(3, 2, vec![1.0, 2.0, 1.0, 3.0, 1.0, 4.0]);
     let targets = Matrix::new(3,2, vec![1.0, 2.0, 1.0, 3.0, 1.0, 4.0]);
 
-    model.init_algorithm = InitAlgorithm::Forgy;
     model.train(&inputs);
 
     let outputs = model.predict(&targets);
@@ -46,11 +45,10 @@ fn test_model_forgy() {
 
 #[test]
 fn test_model_ran_partition() {
-    let mut model = KMeansClassifier::new(3);
+    let mut model = KMeansClassifier::new_specified(3, 100, RandomPartition);
     let inputs = Matrix::new(3, 2, vec![1.0, 2.0, 1.0, 3.0, 1.0, 4.0]);
     let targets = Matrix::new(3,2, vec![1.0, 2.0, 1.0, 3.0, 1.0, 4.0]);
 
-    model.init_algorithm = InitAlgorithm::RandomPartition;
     model.train(&inputs);
 
     let outputs = model.predict(&targets);
@@ -60,11 +58,10 @@ fn test_model_ran_partition() {
 
 #[test]
 fn test_model_kplusplus() {
-    let mut model = KMeansClassifier::new(3);
+    let mut model = KMeansClassifier::new_specified(3, 100, KPlusPlus);
     let inputs = Matrix::new(3, 2, vec![1.0, 2.0, 1.0, 3.0, 1.0, 4.0]);
     let targets = Matrix::new(3,2, vec![1.0, 2.0, 1.0, 3.0, 1.0, 4.0]);
 
-    model.init_algorithm = InitAlgorithm::KPlusPlus;
     model.train(&inputs);
 
     let outputs = model.predict(&targets);
@@ -75,7 +72,7 @@ fn test_model_kplusplus() {
 #[test]
 #[should_panic]
 fn test_no_train_predict() {
-    let model = KMeansClassifier::new(3);
+    let model = KMeansClassifier::<KPlusPlus>::new(3);
     let inputs = Matrix::new(3, 2, vec![1.0, 2.0, 1.0, 3.0, 1.0, 4.0]);
 
     model.predict(&inputs);


### PR DESCRIPTION
This PR should resolves #82 and part of #81 .

## Error Handling

It adds a new error handling module which will allow us to utilize results readily through the learning module. I kept this error module to just the learning side of rusty-machine as I plan to pull the linalg part into a new crate soon<sup>tm</sup>.

## K-Means restructuring

It also restructures the K-Means module by providing a trait for the initialization algorithm. This has the benefit of providing more flexibility to the user. The downside is an arguably more complex interface (not convinced of this). And more importantly we lose the Builder model we had before - this is because the type of the initialization algorithm must be confirmed as soon as we create the struct.

## Breaking changes

The above means some breaking changes to K-means. In addition to that described above I have made the fields on the KMeansClassifier private (with helper methods providing access).

If you have time (and the interest) it would be good to get some feedback from @zackmdavis and @danlrobertson  . You were both involved with the K-means discussion in #30 a while ago. Of course feedback from anyone else is welcome!

I'm not sure if this should be merged now and swept under the rug as a 0.3.X release or included with further changes later. I'm leaning towards breaking the rules again...