### PR TITLE
Use unsafe set_len and direct indexing in variance

### DIFF
--- a/rusty-machine/src/linalg/matrix/mod.rs
+++ b/rusty-machine/src/linalg/matrix/mod.rs
@@ -916,10 +916,12 @@ impl<T: Float + FromPrimitive> Matrix<T> {
             let mut t = Vec::<T>::with_capacity(m);
 
             unsafe {
+                t.set_len(m);
+                
                 for j in 0..m {
-                    match axis {
-                        Axes::Row => t.push(*self.data.get_unchecked(i * m + j)),
-                        Axes::Col => t.push(*self.data.get_unchecked(j * n + i)),
+                    t[j] = match axis {
+                        Axes::Row => *self.data.get_unchecked(i * m + j),
+                        Axes::Col => *self.data.get_unchecked(j * n + i),
                     }
 
                 }

--- a/rusty-machine/src/linalg/matrix/mod.rs
+++ b/rusty-machine/src/linalg/matrix/mod.rs
@@ -910,7 +910,7 @@ impl<T: Float + FromPrimitive> Matrix<T> {
             }
         }
 
-        let mut variance = Vector::new(vec![T::zero(); m]);
+        let mut variance = Vector::zeros(m);
 
         for i in 0..n {
             let mut t = Vec::<T>::with_capacity(m);


### PR DESCRIPTION
This was suggested in #85 

I'm not sure if it was worth it to pull out the `t[j] `outside of the `match` what is your opinion?