### PR TITLE
Use Option<&Type> instead of &Option<Type>

### DIFF
--- a/rusty-machine/src/learning/gmm.rs
+++ b/rusty-machine/src/learning/gmm.rs
@@ -183,8 +183,8 @@ impl GaussianMixtureModel {
     /// Returns a reference to the Option<Matrix<f64>>
     /// which contains the model means. Each row represents
     /// the mean of one of the Gaussians.
-    pub fn means(&self) -> &Option<Matrix<f64>> {
-        &self.model_means
+    pub fn means(&self) -> Option<&Matrix<f64>> {
+        self.model_means.as_ref()
     }
 
     /// The model covariances
@@ -192,8 +192,8 @@ impl GaussianMixtureModel {
     /// Returns a reference to the Option<Vec<Matrix<f64>>>
     /// which contains the model covariances. Each Matrix in
     /// the vector is the covariance of one of the Gaussians.
-    pub fn covariances(&self) -> &Option<Vec<Matrix<f64>>> {
-        &self.model_covars
+    pub fn covariances(&self) -> Option<&Vec<Matrix<f64>>> {
+        self.model_covars.as_ref()
     }
 
     /// The model mixture weights
@@ -318,14 +318,14 @@ mod tests {
     fn test_means_none() {
         let model = GaussianMixtureModel::new(5);
 
-        assert_eq!(model.means(), &None);
+        assert_eq!(model.means(), None);
     }
 
     #[test]
     fn test_covars_none() {
         let model = GaussianMixtureModel::new(5);
 
-        assert_eq!(model.covariances(), &None);
+        assert_eq!(model.covariances(), None);
     }
 
     #[test]

--- a/rusty-machine/src/learning/gmm.rs
+++ b/rusty-machine/src/learning/gmm.rs
@@ -180,8 +180,8 @@ impl GaussianMixtureModel {
 
     /// The model means
     ///
-    /// Returns a reference to the Option<Matrix<f64>>
-    /// which contains the model means. Each row represents
+    /// Returns an Option<&Matrix<f64>> containing
+    /// the model means. Each row represents
     /// the mean of one of the Gaussians.
     pub fn means(&self) -> Option<&Matrix<f64>> {
         self.model_means.as_ref()
@@ -189,9 +189,9 @@ impl GaussianMixtureModel {
 
     /// The model covariances
     ///
-    /// Returns a reference to the Option<Vec<Matrix<f64>>>
-    /// which contains the model covariances. Each Matrix in
-    /// the vector is the covariance of one of the Gaussians.
+    /// Returns an Option<&Vec<Matrix<f64>>> containing
+    /// the model covariances. Each Matrix in the vector
+    /// is the covariance of one of the Gaussians.
     pub fn covariances(&self) -> Option<&Vec<Matrix<f64>>> {
         self.model_covars.as_ref()
     }

--- a/rusty-machine/src/learning/lin_reg.rs
+++ b/rusty-machine/src/learning/lin_reg.rs
@@ -58,11 +58,8 @@ impl LinRegressor {
     /// Get the parameters from the model.
     ///
     /// Returns an option that is None if the model has not been trained.
-    pub fn parameters(&self) -> Option<Vector<f64>> {
-        match self.parameters {
-            None => None,
-            Some(ref x) => Some(x.clone()),
-        }
+    pub fn parameters(&self) -> Option<&Vector<f64>> {
+        self.parameters.as_ref()
     }
 }
 

--- a/rusty-machine/src/learning/logistic_reg.rs
+++ b/rusty-machine/src/learning/logistic_reg.rs
@@ -86,11 +86,8 @@ impl<A: OptimAlgorithm<BaseLogisticRegressor>> LogisticRegressor<A> {
     /// Get the parameters from the model.
     ///
     /// Returns an option that is None if the model has not been trained.
-    pub fn parameters(&self) -> Option<Vector<f64>> {
-        match *self.base.parameters() {
-            Some(ref p) => Some(p.clone()),
-            None => None,
-        }
+    pub fn parameters(&self) -> Option<&Vector<f64>> {
+        self.base.parameters()
     }
 }
 
@@ -129,7 +126,7 @@ impl<A> SupModel<Matrix<f64>, Vector<f64>> for LogisticRegressor<A>
     ///
     /// Model must be trained before prediction can be made.
     fn predict(&self, inputs: &Matrix<f64>) -> Vector<f64> {
-        if let Some(ref v) = *self.base.parameters() {
+        if let Some(v) = self.base.parameters() {
             let ones = Matrix::<f64>::ones(inputs.rows(), 1);
             let full_inputs = ones.hcat(inputs);
             (full_inputs * v).apply(&Sigmoid::func)
@@ -157,8 +154,8 @@ impl BaseLogisticRegressor {
 
 impl BaseLogisticRegressor {
     /// Returns a reference to the parameters.
-    fn parameters(&self) -> &Option<Vector<f64>> {
-        &self.parameters
+    fn parameters(&self) -> Option<&Vector<f64>> {
+        self.parameters.as_ref()
     }
 
     /// Set the parameters to `Some` vector.

--- a/rusty-machine/src/learning/naive_bayes.rs
+++ b/rusty-machine/src/learning/naive_bayes.rs
@@ -79,22 +79,22 @@ impl<T: Distribution> NaiveBayes<T> {
     /// Get the cluster count for this model.
     ///
     /// Returns an option which is `None` until the model has been trained.
-    pub fn cluster_count(&self) -> &Option<usize> {
-        &self.cluster_count
+    pub fn cluster_count(&self) -> Option<&usize> {
+        self.cluster_count.as_ref()
     }
 
     /// Get the class prior distribution for this model.
     ///
     /// Returns an option which is `None` until the model has been trained.
-    pub fn class_prior(&self) -> &Option<Vec<f64>> {
-        &self.class_prior
+    pub fn class_prior(&self) -> Option<&Vec<f64>> {
+        self.class_prior.as_ref()
     }
 
     /// Get the distribution for this model.
     ///
     /// Returns an option which is `None` until the model has been trained.
-    pub fn distr(&self) -> &Option<T> {
-        &self.distr
+    pub fn distr(&self) -> Option<&T> {
+        self.distr.as_ref()
     }
 }
 


### PR DESCRIPTION
More methods provided by Option can be used this way
Fixes #92 

Should the documentation `Returns a reference to the Option<...>` also be changed?