### PR TITLE
Implement IntoIterator for MatrixSlice

### DIFF
--- a/rusty-machine/src/linalg/matrix/iter.rs
+++ b/rusty-machine/src/linalg/matrix/iter.rs
@@ -3,6 +3,7 @@ use std::marker::PhantomData;
 use std::slice;
 
 use super::{Matrix, MatrixSlice, MatrixSliceMut};
+use super::slice::{SliceIter, SliceIterMut};
 
 /// Row iterator.
 #[derive(Debug)]
@@ -322,6 +323,60 @@ impl<'a, T: 'a + Copy> FromIterator<&'a [T]> for Matrix<T> {
     }
 }
 
+impl<'a, T> IntoIterator for MatrixSlice<'a, T> {
+    type Item = &'a T;
+    type IntoIter = SliceIter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a MatrixSlice<'a, T> {
+    type Item = &'a T;
+    type IntoIter = SliceIter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut MatrixSlice<'a, T> {
+    type Item = &'a T;
+    type IntoIter = SliceIter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for MatrixSliceMut<'a, T> {
+    type Item = &'a mut T;
+    type IntoIter = SliceIterMut<'a, T>;
+
+    fn into_iter(mut self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a MatrixSliceMut<'a, T> {
+    type Item = &'a T;
+    type IntoIter = SliceIter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut MatrixSliceMut<'a, T> {
+    type Item = &'a mut T;
+    type IntoIter = SliceIterMut<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
 #[cfg(test)]
 mod tests {
 
@@ -459,4 +514,46 @@ mod tests {
 
     }
 
+    #[test]
+    #[allow(unused_variables)]
+    fn into_iter_compile() { 
+        let a = Matrix::new(3, 3, vec![2.0; 9]); 
+        let mut b = MatrixSlice::from_matrix(&a, [1, 1], 2, 2);
+    
+        for v in b { 
+        } 
+    
+        for v in &b { 
+        } 
+    
+        for v in &mut b { 
+        } 
+    } 
+    
+    #[test]
+    #[allow(unused_variables)]
+    fn into_iter_mut_compile() { 
+        let mut a = Matrix::new(3, 3, vec![2.0; 9]); 
+        
+        {
+            let b = MatrixSliceMut::from_matrix(&mut a, [1, 1], 2, 2);
+    
+            for v in b { 
+            } 
+        }
+    
+        {
+            let b = MatrixSliceMut::from_matrix(&mut a, [1, 1], 2, 2);
+    
+            for v in &b { 
+            } 
+        }
+    
+        {
+            let mut b = MatrixSliceMut::from_matrix(&mut a, [1, 1], 2, 2);
+    
+            for v in &mut b { 
+            } 
+        }
+    } 
 }

--- a/rusty-machine/src/linalg/matrix/iter.rs
+++ b/rusty-machine/src/linalg/matrix/iter.rs
@@ -515,44 +515,44 @@ mod tests {
     }
 
     #[test]
-    #[allow(unused_variables)]
     fn into_iter_compile() { 
         let a = Matrix::new(3, 3, vec![2.0; 9]); 
         let mut b = MatrixSlice::from_matrix(&a, [1, 1], 2, 2);
     
-        for v in b { 
+        for _ in b { 
         } 
     
-        for v in &b { 
+        for _ in &b { 
         } 
     
-        for v in &mut b { 
+        for _ in &mut b { 
         } 
     } 
     
     #[test]
-    #[allow(unused_variables)]
     fn into_iter_mut_compile() { 
-        let mut a = Matrix::new(3, 3, vec![2.0; 9]); 
+        let mut a = Matrix::<f32>::new(3, 3, vec![2.0; 9]); 
         
         {
             let b = MatrixSliceMut::from_matrix(&mut a, [1, 1], 2, 2);
-    
+                
             for v in b { 
+                *v = 1.0;
             } 
         }
     
         {
             let b = MatrixSliceMut::from_matrix(&mut a, [1, 1], 2, 2);
     
-            for v in &b { 
+            for _ in &b {
             } 
         }
     
         {
             let mut b = MatrixSliceMut::from_matrix(&mut a, [1, 1], 2, 2);
     
-            for v in &mut b { 
+            for v in &mut b {
+                *v = 1.0; 
             } 
         }
     } 

--- a/rusty-machine/src/linalg/matrix/slice.rs
+++ b/rusty-machine/src/linalg/matrix/slice.rs
@@ -357,7 +357,7 @@ impl<'a, T> MatrixSliceMut<'a, T> {
     /// let slice_data = slice.iter().map(|v| *v).collect::<Vec<usize>>();
     /// assert_eq!(slice_data, vec![4,5,7,8]);
     /// ```
-    pub fn iter(&self) -> SliceIter<T> {
+    pub fn iter(&self) -> SliceIter<'a, T> {
         SliceIter {
             slice_start: self.ptr as *const T,
             row_pos: 0,
@@ -390,7 +390,7 @@ impl<'a, T> MatrixSliceMut<'a, T> {
     /// // Only the matrix slice is updated.
     /// assert_eq!(a.into_vec(), vec![0,1,2,3,6,7,6,9,10]);
     /// ```
-    pub fn iter_mut(&mut self) -> SliceIterMut<T> {
+    pub fn iter_mut(&mut self) -> SliceIterMut<'a, T> {
         SliceIterMut {
             slice_start: self.ptr,
             row_pos: 0,
@@ -408,6 +408,33 @@ impl<'a, T: Copy> MatrixSliceMut<'a, T> {
     /// Convert the matrix slice into a new Matrix.
     pub fn into_matrix(self) -> Matrix<T> {
         self.iter_rows().collect::<Matrix<T>>()
+    }
+}
+
+impl<'a, T> IntoIterator for MatrixSliceMut<'a, T> {
+    type Item = &'a mut T;
+    type IntoIter = SliceIterMut<'a, T>;
+
+    fn into_iter(mut self) -> Self::IntoIter {
+        self.iter_mut()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a MatrixSliceMut<'a, T> {
+    type Item = &'a T;
+    type IntoIter = SliceIter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut MatrixSliceMut<'a, T> {
+    type Item = &'a mut T;
+    type IntoIter = SliceIterMut<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter_mut()
     }
 }
 
@@ -547,6 +574,7 @@ mod tests {
     }
     
     #[test]
+    #[allow(unused_variables)]
     fn into_iter_compile() { 
         let a = Matrix::new(3, 3, vec![2.0; 9]); 
         let mut b = MatrixSlice::from_matrix(&a, [1, 1], 2, 2);
@@ -561,4 +589,30 @@ mod tests {
         } 
     } 
     
+    #[test]
+    #[allow(unused_variables)]
+    fn into_iter_mut_compile() { 
+        let mut a = Matrix::new(3, 3, vec![2.0; 9]); 
+        
+        {
+            let b = MatrixSliceMut::from_matrix(&mut a, [1, 1], 2, 2);
+    
+            for v in b { 
+            } 
+        }
+    
+        {
+            let b = MatrixSliceMut::from_matrix(&mut a, [1, 1], 2, 2);
+    
+            for v in &b { 
+            } 
+        }
+    
+        {
+            let mut b = MatrixSliceMut::from_matrix(&mut a, [1, 1], 2, 2);
+    
+            for v in &mut b { 
+            } 
+        }
+    } 
 }

--- a/rusty-machine/src/linalg/matrix/slice.rs
+++ b/rusty-machine/src/linalg/matrix/slice.rs
@@ -545,4 +545,20 @@ mod tests {
         assert_eq!(e.rows(), 2);
         assert_eq!(e.cols(), 2);
     }
+    
+    #[test]
+    fn into_iter_compile() { 
+        let a = Matrix::new(3, 3, vec![2.0; 9]); 
+        let mut b = MatrixSlice::from_matrix(&a, [1, 1], 2, 2);
+    
+        for v in b { 
+        } 
+    
+        for v in &b { 
+        } 
+    
+        for v in &mut b { 
+        } 
+    } 
+    
 }

--- a/rusty-machine/src/linalg/matrix/slice.rs
+++ b/rusty-machine/src/linalg/matrix/slice.rs
@@ -196,7 +196,7 @@ impl<'a, T> MatrixSlice<'a, T> {
     /// let slice_data = slice.iter().map(|v| *v).collect::<Vec<usize>>();
     /// assert_eq!(slice_data, vec![4,5,7,8]);
     /// ```
-    pub fn iter<'b>(&self) -> SliceIter<'b, T> {
+    pub fn iter(&self) -> SliceIter<'a, T> {
         SliceIter {
             slice_start: self.ptr,
             row_pos: 0,
@@ -204,7 +204,7 @@ impl<'a, T> MatrixSlice<'a, T> {
             slice_rows: self.rows,
             slice_cols: self.cols,
             row_stride: self.row_stride,
-            _marker: PhantomData::<&'b T>,
+            _marker: PhantomData::<&'a T>,
         }
     }
 }

--- a/rusty-machine/src/linalg/matrix/slice.rs
+++ b/rusty-machine/src/linalg/matrix/slice.rs
@@ -196,7 +196,7 @@ impl<'a, T> MatrixSlice<'a, T> {
     /// let slice_data = slice.iter().map(|v| *v).collect::<Vec<usize>>();
     /// assert_eq!(slice_data, vec![4,5,7,8]);
     /// ```
-    pub fn iter(&self) -> SliceIter<T> {
+    pub fn iter<'b>(&self) -> SliceIter<'b, T> {
         SliceIter {
             slice_start: self.ptr,
             row_pos: 0,
@@ -204,7 +204,7 @@ impl<'a, T> MatrixSlice<'a, T> {
             slice_rows: self.rows,
             slice_cols: self.cols,
             row_stride: self.row_stride,
-            _marker: PhantomData::<&'a T>,
+            _marker: PhantomData::<&'b T>,
         }
     }
 }
@@ -213,6 +213,33 @@ impl<'a, T: Copy> MatrixSlice<'a, T> {
     /// Convert the matrix slice into a new Matrix.
     pub fn into_matrix(self) -> Matrix<T> {
         self.iter_rows().collect::<Matrix<T>>()
+    }
+}
+
+impl<'a, T> IntoIterator for MatrixSlice<'a, T> {
+    type Item = &'a T;
+    type IntoIter = SliceIter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a MatrixSlice<'a, T> {
+    type Item = &'a T;
+    type IntoIter = SliceIter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a mut MatrixSlice<'a, T> {
+    type Item = &'a T;
+    type IntoIter = SliceIter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
     }
 }
 

--- a/rusty-machine/src/linalg/matrix/slice.rs
+++ b/rusty-machine/src/linalg/matrix/slice.rs
@@ -216,33 +216,6 @@ impl<'a, T: Copy> MatrixSlice<'a, T> {
     }
 }
 
-impl<'a, T> IntoIterator for MatrixSlice<'a, T> {
-    type Item = &'a T;
-    type IntoIter = SliceIter<'a, T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
-    }
-}
-
-impl<'a, T> IntoIterator for &'a MatrixSlice<'a, T> {
-    type Item = &'a T;
-    type IntoIter = SliceIter<'a, T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
-    }
-}
-
-impl<'a, T> IntoIterator for &'a mut MatrixSlice<'a, T> {
-    type Item = &'a T;
-    type IntoIter = SliceIter<'a, T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
-    }
-}
-
 impl<'a, T> MatrixSliceMut<'a, T> {
     /// Produce a matrix slice from a matrix
     ///
@@ -403,38 +376,10 @@ impl<'a, T> MatrixSliceMut<'a, T> {
     }
 }
 
-
 impl<'a, T: Copy> MatrixSliceMut<'a, T> {
     /// Convert the matrix slice into a new Matrix.
     pub fn into_matrix(self) -> Matrix<T> {
         self.iter_rows().collect::<Matrix<T>>()
-    }
-}
-
-impl<'a, T> IntoIterator for MatrixSliceMut<'a, T> {
-    type Item = &'a mut T;
-    type IntoIter = SliceIterMut<'a, T>;
-
-    fn into_iter(mut self) -> Self::IntoIter {
-        self.iter_mut()
-    }
-}
-
-impl<'a, T> IntoIterator for &'a MatrixSliceMut<'a, T> {
-    type Item = &'a T;
-    type IntoIter = SliceIter<'a, T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter()
-    }
-}
-
-impl<'a, T> IntoIterator for &'a mut MatrixSliceMut<'a, T> {
-    type Item = &'a mut T;
-    type IntoIter = SliceIterMut<'a, T>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.iter_mut()
     }
 }
 
@@ -572,47 +517,4 @@ mod tests {
         assert_eq!(e.rows(), 2);
         assert_eq!(e.cols(), 2);
     }
-    
-    #[test]
-    #[allow(unused_variables)]
-    fn into_iter_compile() { 
-        let a = Matrix::new(3, 3, vec![2.0; 9]); 
-        let mut b = MatrixSlice::from_matrix(&a, [1, 1], 2, 2);
-    
-        for v in b { 
-        } 
-    
-        for v in &b { 
-        } 
-    
-        for v in &mut b { 
-        } 
-    } 
-    
-    #[test]
-    #[allow(unused_variables)]
-    fn into_iter_mut_compile() { 
-        let mut a = Matrix::new(3, 3, vec![2.0; 9]); 
-        
-        {
-            let b = MatrixSliceMut::from_matrix(&mut a, [1, 1], 2, 2);
-    
-            for v in b { 
-            } 
-        }
-    
-        {
-            let b = MatrixSliceMut::from_matrix(&mut a, [1, 1], 2, 2);
-    
-            for v in &b { 
-            } 
-        }
-    
-        {
-            let mut b = MatrixSliceMut::from_matrix(&mut a, [1, 1], 2, 2);
-    
-            for v in &mut b { 
-            } 
-        }
-    } 
 }


### PR DESCRIPTION
Fixes part of #94 but first I want to discuss some things with this implementation.

1. I changed `MatrixSlice.iter()` to take an external lifetime bound. It seems to compile this way but I'm not sure if it is correct. This was necessary since the deducted lifetime was invalid `into_iter` takes `self` as `Self` and so the borrowed value was only alive inside the method.
2. I duplicated the implementation for all three cases `value`, `&` and `&mut` this could surly be solved with some macro-magic. Would be nice if someone could help me there.
3. I'm not sure how to test this. The only thing that comes in mind is that I could manually iterate and check each value individually but that seems like a lot of duplicated code.


Small compile test
```rust
fn into_test() { 
    let a = Matrix::new(3, 3, vec![2.0; 9]); 
    let mut b = MatrixSlice::from_matrix(&a, [1, 1], 2, 2);
    
    for v in b { 
    } 
    
    {
        let x = &b; 
        for v in x { 
        }
    }
    
    {
        let y = &mut b;
        for v in y { 
        }
    }
} 
```