### PR TITLE
DBSCAN

### DIFF
--- a/src/learning/dbscan.rs
+++ b/src/learning/dbscan.rs
@@ -55,6 +55,8 @@ impl UnSupModel<Matrix<f64>, Vector<usize>> for DBSCAN {
 impl DBSCAN {
     /// Create a new DBSCAN model.
     pub fn new(eps: f64, min_points: usize) -> DBSCAN {
+        assert!(eps > 0f64, "The model epsilon must be positive.");
+
         DBSCAN {
             eps: eps,
             min_points: min_points,
@@ -129,6 +131,30 @@ impl DBSCAN {
     }
 }
 
-
 #[cfg(test)]
-mod tests {}
+mod tests {
+    use super::DBSCAN;
+    use linalg::Matrix;
+
+    #[test]
+    fn test_region_query() {
+        let model = DBSCAN::new(1.0, 3);
+
+        let inputs = Matrix::new(3, 2, vec![1.0, 1.0, 1.1, 1.9, 3.0, 3.0]);
+
+        let neighbours = model.region_query(&[1.0, 1.0], &inputs);
+
+        assert!(neighbours.len() == 2);
+    }
+
+    #[test]
+    fn test_region_query_small_eps() {
+        let model = DBSCAN::new(0.01, 3);
+
+        let inputs = Matrix::new(3, 2, vec![1.0, 1.0, 1.1, 1.9, 1.1, 1.1]);
+
+        let neighbours = model.region_query(&[1.0, 1.0], &inputs);
+
+        assert!(neighbours.len() == 1);
+    }
+}

--- a/src/learning/dbscan.rs
+++ b/src/learning/dbscan.rs
@@ -1,0 +1,134 @@
+//! DBSCAN
+
+use learning::UnSupModel;
+
+use linalg::{Matrix, Vector};
+use rulinalg::utils;
+
+/// DBSCAN Model
+#[derive(Debug)]
+pub struct DBSCAN {
+    eps: f64,
+    min_points: usize,
+    clusters: Option<Vector<Option<usize>>>,
+    _visited: Vec<bool>,
+}
+
+impl Default for DBSCAN {
+    fn default() -> DBSCAN {
+        DBSCAN {
+            eps: 0.5,
+            min_points: 5,
+            clusters: None,
+            _visited: Vec::new(),
+        }
+    }
+}
+
+impl UnSupModel<Matrix<f64>, Vector<usize>> for DBSCAN {
+    /// Train the classifier using input data.
+    fn train(&mut self, inputs: &Matrix<f64>) {
+        self.init_params(inputs.rows());
+        let mut cluster = 0;
+
+        for (idx, point) in inputs.iter_rows().enumerate() {
+            let visited = self._visited[idx];
+
+            if !visited {
+                self._visited[idx] = true;
+
+                let neighbours = self.region_query(point, inputs);
+
+                if neighbours.len() >= self.min_points {
+                    self.expand_cluster(inputs, idx, neighbours, cluster);
+                    cluster += 1;
+                }
+            }
+        }
+    }
+
+    fn predict(&self, _: &Matrix<f64>) -> Vector<usize> {
+        unimplemented!();
+    }
+}
+
+impl DBSCAN {
+    /// Create a new DBSCAN model.
+    pub fn new(eps: f64, min_points: usize) -> DBSCAN {
+        DBSCAN {
+            eps: eps,
+            min_points: min_points,
+            clusters: None,
+            _visited: Vec::new(),
+        }
+    }
+
+    /// Return an Option pointing to the model clusters.
+    pub fn cluster(&self) -> Option<&Vector<Option<usize>>> {
+        self.clusters.as_ref()
+    }
+
+    fn expand_cluster(&mut self,
+                      inputs: &Matrix<f64>,
+                      point_idx: usize,
+                      neighbour_pts: Vec<usize>,
+                      cluster: usize) {
+        debug_assert!(point_idx < inputs.rows(),
+                      "Point index too large for inputs");
+        debug_assert!(neighbour_pts.iter().all(|x| *x < inputs.rows()),
+                      "Neighbour indices too large for inputs");
+
+        self.clusters.as_mut().map(|x| x.mut_data()[point_idx] = Some(cluster));
+
+        for data_point_idx in &neighbour_pts {
+            let visited = self._visited[*data_point_idx];
+            if !visited {
+                self._visited[*data_point_idx] = true;
+                let sub_neighbours =
+                    self.region_query(&inputs.data()[data_point_idx * inputs.cols()..(data_point_idx +
+                                                                                   1) *
+                                                                                  inputs.cols()],
+                                      inputs);
+
+                if sub_neighbours.len() >= self.min_points {
+                    self.expand_cluster(inputs, *data_point_idx, sub_neighbours, cluster);
+                }
+            }
+        }
+    }
+
+
+    fn region_query(&self, point: &[f64], inputs: &Matrix<f64>) -> Vec<usize> {
+        debug_assert!(point.len() == inputs.cols(),
+                      "point must be of same dimension as inputs");
+
+        let mut in_neighbourhood = Vec::new();
+        for (idx, data_point) in inputs.iter_rows().enumerate() {
+            let point_distance = utils::vec_bin_op(data_point, point, |x, y| x - y);
+            let dist = utils::dot(&point_distance, &point_distance).sqrt();
+
+            if dist < self.eps {
+                in_neighbourhood.push(idx);
+            }
+        }
+
+        in_neighbourhood
+    }
+
+    fn init_params(&mut self, total_points: usize) {
+        unsafe {
+            self._visited.reserve(total_points);
+            self._visited.set_len(total_points);
+        }
+
+        for i in 0..total_points {
+            self._visited[i] = false;
+        }
+
+        self.clusters = Some(Vector::new(vec![None; total_points]));
+    }
+}
+
+
+#[cfg(test)]
+mod tests {}

--- a/src/learning/dbscan.rs
+++ b/src/learning/dbscan.rs
@@ -1,5 +1,8 @@
 //! DBSCAN Clustering
 //!
+//! *Note: This module is likely to change dramatically in the future and
+//! should be treated as experimental.*
+//!
 //! Provides an implementaton of DBSCAN clustering. The model
 //! also implements a `predict` function which uses nearest neighbours
 //! to classify the points. To utilize this function you must use
@@ -9,6 +12,9 @@
 //! The `eps` parameter controls how close together points must be to be
 //! placed in the same cluster. The `min_points` parameter controls how many
 //! points must be within distance `eps` of eachother to be considered a cluster.
+//!
+//! If a point is not within distance `eps` of a cluster it will be classified
+//! as noise. This means that it will be set to `None` in the clusters `Vector`.
 //!
 //! # Examples
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,7 @@ pub mod linalg {
 
 /// Module for machine learning.
 pub mod learning {
+    pub mod dbscan;
     pub mod glm;
     pub mod gmm;
     pub mod lin_reg;

--- a/tests/learning/dbscan.rs
+++ b/tests/learning/dbscan.rs
@@ -15,9 +15,29 @@ fn test_basic_clusters() {
     let mut model = DBSCAN::new(0.5, 2);
     model.train(&inputs);
 
-    let clustering = model.cluster().unwrap();
+    let clustering = model.clusters().unwrap();
 
     assert!(clustering.data().iter().take(4).all(|x| *x == Some(0)));
     assert!(clustering.data().iter().skip(4).all(|x| *x == Some(1)));
 }
 
+
+#[test]
+fn test_basic_prediction() {
+    let inputs = Matrix::new(6, 2, vec![1.0, 2.0,
+                                        1.1, 2.2,
+                                        0.9, 1.9,
+                                        1.0, 2.1,
+                                        -2.0, 3.0,
+                                        -2.2, 3.1]);
+
+    let mut model = DBSCAN::new(0.5, 2);
+    model.set_predictive(true);
+    model.train(&inputs);
+
+    let new_points = Matrix::new(2,2, vec![1.0, 2.0, 4.0, 4.0]);
+
+    let classes = model.predict(&new_points);
+    assert!(classes[0] == Some(0));
+    assert!(classes[1] == None);
+}

--- a/tests/learning/dbscan.rs
+++ b/tests/learning/dbscan.rs
@@ -1,0 +1,23 @@
+use rm::linalg::Matrix;
+
+use rm::learning::dbscan::DBSCAN;
+use rm::learning::UnSupModel;
+
+#[test]
+fn test_basic_clusters() {
+    let inputs = Matrix::new(6, 2, vec![1.0, 2.0,
+                                        1.1, 2.2,
+                                        0.9, 1.9,
+                                        1.0, 2.1,
+                                        -2.0, 3.0,
+                                        -2.2, 3.1]);
+
+    let mut model = DBSCAN::new(0.5, 2);
+    model.train(&inputs);
+
+    let clustering = model.cluster().unwrap();
+
+    assert!(clustering.data().iter().take(4).all(|x| *x == Some(0)));
+    assert!(clustering.data().iter().skip(4).all(|x| *x == Some(1)));
+}
+

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -2,6 +2,7 @@ extern crate rusty_machine as rm;
 extern crate num as libnum;
 
 pub mod learning {
+    mod dbscan;
     mod lin_reg;
     mod k_means;
     mod gp;


### PR DESCRIPTION
This PR resolves #100 .

The PR adds a simple implementation of the DBSCAN algorithm. There is some hacky work around getting the `predict` method of the `UnSupModel` trait to work. We need to clone the data to do prediction and so we make this heavy task gated behind a `predictive` property of the model which must be explicitly set.

In future it may be a good idea to add a `Clustering` trait which does not require the `predict` method. We can then implement this trait for DBSCAN/K-Means/Nearest neighbours. The only obvious downside is that we'd need universal function syntax to distinguish if we used the same function names (or we use different names which may add some complication).