### PR TITLE
Nnet rewrite

### DIFF
--- a/src/learning/nnet.rs
+++ b/src/learning/nnet.rs
@@ -311,9 +311,9 @@ impl<'a, T: Criterion> BaseNeuralNet<'a, T> {
             }
         }
 
-        let mut gradients = Vec::new();
+        let mut gradients = Vec::with_capacity(weights.len());
 
-        for (l, activ_item) in activations[..self.layer_sizes.len() - 1].iter().enumerate() {
+        for (l, activ_item) in activations.iter().take(self.layer_sizes.len() - 1).enumerate() {
             // Compute the gradient
             let mut g = deltas[self.layer_sizes.len() - 2 - l].transpose() * activ_item;
 
@@ -333,9 +333,9 @@ impl<'a, T: Criterion> BaseNeuralNet<'a, T> {
 
         // Add the regularized cost
         if self.criterion.is_regularized() {
-            cost += (0..self.layer_sizes.len() - 1)
-                .map(|i| self.criterion.reg_cost(self.get_non_bias_weights(weights, i)))
-                .sum();
+            for i in 0..self.layer_sizes.len() - 1 {
+                cost += self.criterion.reg_cost(self.get_non_bias_weights(weights, i));
+            }
         }
 
         (cost, gradients)

--- a/src/learning/nnet.rs
+++ b/src/learning/nnet.rs
@@ -179,11 +179,7 @@ pub struct BaseNeuralNet<'a, T: Criterion> {
 impl<'a> BaseNeuralNet<'a, BCECriterion> {
     /// Creates a base neural network with the specified layer sizes.
     fn default(layer_sizes: &[usize]) -> BaseNeuralNet<BCECriterion> {
-        BaseNeuralNet {
-            layer_sizes: layer_sizes,
-            weights: BaseNeuralNet::<BCECriterion>::create_weights(layer_sizes),
-            criterion: BCECriterion::default(),
-        }
+        BaseNeuralNet::new(layer_sizes, BCECriterion::default())
     }
 }
 
@@ -279,8 +275,8 @@ impl<'a, T: Criterion> BaseNeuralNet<'a, T> {
 
                 a = ones.hcat(&a);
 
-                activations.push(a.clone());
-                z = a * self.get_layer_weights(weights, l);
+                z = &a * self.get_layer_weights(weights, l);
+                activations.push(a);
                 forward_weights.push(z.clone());
             }
 


### PR DESCRIPTION
Small rewrite of nnet module.

- in `create_weights`: use `rand::distributions::range::Range` as [advised on rand doc](https://doc.rust-lang.org/rand/rand/trait.Rng.html#method.gen_range)
  - removed `initialize_weights` function and put the logic directly in `create_weights`
- in `compute_grad`: remove an  unecessary intermediary `grad` vector. On my very unscientific test, running the example `nnet-and_gate` is 2.5 % faster.
