### PR TITLE
Remove several select_rows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,6 @@ license = "MIT"
 stats = []
 
 [dependencies]
-num = { version = "0.1.32", default-features = false }
+num = { version = "0.1.34", default-features = false }
 rand = "0.3.14"
-rulinalg = "0.2.0"
+rulinalg = "0.2.1"

--- a/src/learning/dbscan.rs
+++ b/src/learning/dbscan.rs
@@ -178,8 +178,8 @@ impl DBSCAN {
             let visited = self._visited[*data_point_idx];
             if !visited {
                 self._visited[*data_point_idx] = true;
-                let sub_neighbours = self.region_query(inputs.select_rows(&[*data_point_idx]).data(),
-                                                       inputs);
+                let data_point_row = unsafe { inputs.get_row_unchecked(*data_point_idx) };
+                let sub_neighbours = self.region_query(data_point_row, inputs);
 
                 if sub_neighbours.len() >= self.min_points {
                     self.expand_cluster(inputs, *data_point_idx, sub_neighbours, cluster);

--- a/src/learning/gmm.rs
+++ b/src/learning/gmm.rs
@@ -293,7 +293,7 @@ impl GaussianMixtureModel {
             for i in 0..n {
                 let inputs_i = MatrixSlice::from_matrix(inputs, [i, 0], 1, d);
                 let diff = inputs_i - new_means_k; 
-                cov_mat += self.compute_cov(&diff, membership_weights[[i, k]]);
+                cov_mat += self.compute_cov(diff, membership_weights[[i, k]]);
             }
             new_covs.push(cov_mat / sum_weights[k]);
 
@@ -303,7 +303,7 @@ impl GaussianMixtureModel {
         self.model_covars = Some(new_covs);
     }
 
-    fn compute_cov(&self, diff: &Matrix<f64>, weight: f64) -> Matrix<f64> {
+    fn compute_cov(&self, diff: Matrix<f64>, weight: f64) -> Matrix<f64> {
         match self.cov_option {
             CovOption::Full => (diff.transpose() * diff) * weight,
             CovOption::Regularized(eps) => (diff.transpose() * diff) * weight + eps,

--- a/src/learning/gmm.rs
+++ b/src/learning/gmm.rs
@@ -31,8 +31,7 @@
 //! println!("{:?}", post_probs.data());
 //! ```
 
-use linalg::Vector;
-use linalg::Matrix;
+use linalg::{Matrix, MatrixSlice, Vector};
 use rulinalg::utils;
 
 use learning::UnSupModel;
@@ -245,11 +244,11 @@ impl GaussianMixtureModel {
         if let Some(ref means) = self.model_means {
             for i in 0..n {
                 let mut pdfs = Vec::with_capacity(self.comp_count);
-                let x_i = inputs.select_rows(&[i]);
+                let x_i = MatrixSlice::from_matrix(inputs, [i, 0], 1, inputs.cols());
 
                 for j in 0..self.comp_count {
-                    let mu_j = means.select_rows(&[j]);
-                    let diff = &x_i - mu_j;
+                    let mu_j = MatrixSlice::from_matrix(means, [j, 0], 1, means.cols());
+                    let diff = x_i - mu_j;
 
                     let pdf = (&diff * &cov_invs[j] * diff.transpose() * -0.5).into_vec()[0]
                         .exp() / cov_sqrt_dets[j];
@@ -289,10 +288,12 @@ impl GaussianMixtureModel {
 
         for k in 0..self.comp_count {
             let mut cov_mat = Matrix::zeros(d, d);
+            let new_means_k = MatrixSlice::from_matrix(&new_means, [k, 0], 1, d);
 
             for i in 0..n {
-                let diff = inputs.select_rows(&[i]) - new_means.select_rows(&[k]);
-                cov_mat = cov_mat + self.compute_cov(diff, membership_weights[[i, k]]);
+                let inputs_i = MatrixSlice::from_matrix(inputs, [i, 0], 1, d);
+                let diff = inputs_i - new_means_k; 
+                cov_mat += self.compute_cov(&diff, membership_weights[[i, k]]);
             }
             new_covs.push(cov_mat / sum_weights[k]);
 
@@ -302,7 +303,7 @@ impl GaussianMixtureModel {
         self.model_covars = Some(new_covs);
     }
 
-    fn compute_cov(&self, diff: Matrix<f64>, weight: f64) -> Matrix<f64> {
+    fn compute_cov(&self, diff: &Matrix<f64>, weight: f64) -> Matrix<f64> {
         match self.cov_option {
             CovOption::Full => (diff.transpose() * diff) * weight,
             CovOption::Regularized(eps) => (diff.transpose() * diff) * weight + eps,

--- a/src/learning/k_means.rs
+++ b/src/learning/k_means.rs
@@ -209,14 +209,13 @@ impl<InitAlg: Initializer> KMeansClassifier<InitAlg> {
     /// Used internally within model.
     fn update_centroids(&mut self, inputs: &Matrix<f64>, classes: Vector<usize>) {
         let mut new_centroids = Vec::with_capacity(self.k * inputs.cols());
-        for i in 0..self.k {
-            let vec_i: Vec<usize> = classes.data()
-                .iter()
-                .enumerate()
-                .filter(|&(_, &x)| x == i)
-                .map(|(idx, _)| idx)
-                .collect();
-            
+
+        let mut row_indexes = vec![Vec::new(); self.k];
+        for (i, c) in classes.into_vec().into_iter().enumerate() {
+            row_indexes.get_mut(c as usize).map(|v| v.push(i));
+        }
+
+        for vec_i in row_indexes {
             let mat_i = inputs.select_rows(&vec_i);
             new_centroids.extend(mat_i.mean(Axes::Row).into_vec());
         }
@@ -251,7 +250,6 @@ impl<InitAlg: Initializer> KMeansClassifier<InitAlg> {
             let (min_idx, min_dist) = dist.argmin();
             idx.push(min_idx);
             distances.push(min_dist);
-
         }
 
         (Vector::new(idx), Vector::new(distances))
@@ -295,14 +293,10 @@ impl Initializer for RandomPartition {
         let mut random_assignments = Vec::with_capacity(inputs.rows());
 
         // Populate so we have something in each class.
-        for i in 0..k {
-            random_assignments.push(i);
-        }
+        random_assignments.extend(0..k);
 
         let mut rng = thread_rng();
-        for _ in k..inputs.rows() {
-            random_assignments.push(rng.gen_range(0, k));
-        }
+        random_assignments.extend((k..inputs.rows()).map(|_| rng.gen_range(0, k)));
 
         let mut init_centroids = Vec::with_capacity(k * inputs.cols());
         for i in 0..k {
@@ -312,7 +306,7 @@ impl Initializer for RandomPartition {
                 .collect();
 
             let mat_i = inputs.select_rows(&vec_i);
-            init_centroids.extend(mat_i.mean(Axes::Row).into_vec());
+            init_centroids.extend_from_slice(&*mat_i.mean(Axes::Row).into_vec());
         }
 
         Ok(Matrix::new(k, inputs.cols(), init_centroids))
@@ -330,7 +324,9 @@ impl Initializer for KPlusPlus {
         let mut init_centroids = Vec::with_capacity(k * inputs.cols());
         let first_cen = rng.gen_range(0usize, inputs.rows());
 
-        init_centroids.append(&mut inputs.select_rows(&[first_cen]).into_vec());
+        unsafe { 
+            init_centroids.extend_from_slice(inputs.get_row_unchecked(first_cen)); 
+        }
 
         for i in 1..k {
             unsafe {
@@ -349,7 +345,7 @@ impl Initializer for KPlusPlus {
                 }
 
                 let next_cen = sample_discretely(dist);
-                init_centroids.append(&mut inputs.select_rows(&[next_cen]).into_vec())
+                init_centroids.extend_from_slice(inputs.get_row_unchecked(next_cen)); 
             }
         }
 


### PR DESCRIPTION
Partly closes #110 

Made some minor rewriting, I can roll them back if needed.
Also changed one signature on `Distribution` trait
```rust
fn update_params(&mut self, data: &Matrix<f64>, class: usize)
```
The fn now borrows `data` instead of taking ownership (there were no functional reason I think).

For the remaining `select_rows` one pattern that appears a lot is repeating one particular row and then doing matix operations with it. It looked like a good thing to do so I didn't touch it (I don't know how fast matrix operation is compared to a regular for loop).
