### PR TITLE
Add benches from examples

### DIFF
--- a/benches/k-means_generating_cluster.rs
+++ b/benches/k-means_generating_cluster.rs
@@ -1,0 +1,65 @@
+#![feature(test)]
+
+extern crate rusty_machine;
+extern crate rand;
+extern crate test;
+
+use rusty_machine::linalg::Matrix;
+use rusty_machine::learning::k_means::KMeansClassifier;
+use rusty_machine::learning::UnSupModel;
+
+use rand::thread_rng;
+use rand::distributions::IndependentSample;
+use rand::distributions::normal::Normal;
+
+use test::{Bencher, black_box};
+
+fn generate_data(centroids: &Matrix<f64>,
+                 points_per_centroid: usize,
+                 noise: f64)
+                 -> Matrix<f64> {
+    assert!(centroids.cols() > 0, "Centroids cannot be empty.");
+    assert!(centroids.rows() > 0, "Centroids cannot be empty.");
+    assert!(noise >= 0f64, "Noise must be non-negative.");
+    let mut raw_cluster_data = Vec::with_capacity(centroids.rows() * points_per_centroid *
+                                                  centroids.cols());
+
+    let mut rng = thread_rng();
+    let normal_rv = Normal::new(0f64, noise);
+
+    for _ in 0..points_per_centroid {
+        // Generate points from each centroid
+        for centroid in centroids.iter_rows() {
+            // Generate a point randomly around the centroid
+            let mut point = Vec::with_capacity(centroids.cols());
+            for feature in centroid {
+                point.push(feature + normal_rv.ind_sample(&mut rng));
+            }
+
+            // Push point to raw_cluster_data
+            raw_cluster_data.extend(point);
+        }
+    }
+
+    Matrix::new(centroids.rows() * points_per_centroid,
+                centroids.cols(),
+                raw_cluster_data)
+}
+
+#[bench]
+fn bench_k_means(b: &mut Bencher) {
+
+    const SAMPLES_PER_CENTROID: usize = 2000;
+    // Choose two cluster centers, at (-0.5, -0.5) and (0, 0.5).
+    let centroids = Matrix::new(2, 2, vec![-0.5, -0.5, 0.0, 0.5]);
+
+    // Generate some data randomly around the centroids
+    let samples = generate_data(&centroids, SAMPLES_PER_CENTROID, 0.4);
+
+    b.iter(|| {
+        let mut model = black_box(KMeansClassifier::new(2));
+        model.train(&samples);
+        let _ = black_box(model.centroids().as_ref().unwrap());
+        let _ = black_box(model.predict(&samples));
+    });
+}

--- a/benches/nnet-and_gate.rs
+++ b/benches/nnet-and_gate.rs
@@ -1,0 +1,59 @@
+#![feature(test)]
+
+extern crate rusty_machine;
+extern crate rand;
+extern crate test;
+
+use test::{Bencher, black_box};
+
+use rand::{random, Closed01};
+use std::vec::Vec;
+
+use rusty_machine::learning::nnet::{NeuralNet, BCECriterion};
+use rusty_machine::learning::toolkit::regularization::Regularization;
+use rusty_machine::learning::optim::grad_desc::StochasticGD;
+
+use rusty_machine::linalg::Matrix;
+use rusty_machine::learning::SupModel;
+
+#[bench]
+fn bench_nnet_and_gate(b: &mut Bencher) {
+    const THRESHOLD: f64 = 0.7;
+    const SAMPLES: usize = 1000;
+
+    let mut input_data = Vec::with_capacity(SAMPLES * 2);
+    let mut label_data = Vec::with_capacity(SAMPLES);
+
+    for _ in 0..SAMPLES {
+        // The two inputs are "signals" between 0 and 1
+        let Closed01(left) = random::<Closed01<f64>>();
+        let Closed01(right) = random::<Closed01<f64>>();
+        input_data.push(left);
+        input_data.push(right);
+        if left > THRESHOLD && right > THRESHOLD {
+            label_data.push(1.0);
+        } else {
+            label_data.push(0.0)
+        }
+    }
+
+    let inputs = Matrix::new(SAMPLES, 2, input_data);
+    let targets = Matrix::new(SAMPLES, 1, label_data);
+
+    let layers = &[2, 1];
+    let criterion = BCECriterion::new(Regularization::L2(0.));
+
+    let test_cases = vec![
+        0.0, 0.0,
+        0.0, 1.0,
+        1.0, 1.0,
+        1.0, 0.0,
+        ];
+    let test_inputs = Matrix::new(test_cases.len() / 2, 2, test_cases);
+
+    b.iter(|| {
+        let mut model = black_box(NeuralNet::new(layers, criterion, StochasticGD::default()));
+        model.train(&inputs, &targets);
+        let _ = model.predict(&test_inputs);
+    })
+}

--- a/benches/svm-sign_learner.rs
+++ b/benches/svm-sign_learner.rs
@@ -1,0 +1,44 @@
+#![feature(test)]
+
+extern crate rusty_machine;
+extern crate test;
+
+use rusty_machine::learning::svm::SVM;
+// Necessary for the training trait.
+use rusty_machine::learning::SupModel;
+use rusty_machine::learning::toolkit::kernel::HyperTan;
+
+use rusty_machine::linalg::Matrix;
+use rusty_machine::linalg::Vector;
+
+use test::{Bencher, black_box};
+
+// Sign learner:
+//   * Model input a float number
+//   * Model output: A float representing the input sign.
+//       If the input is positive, the output is close to 1.0.
+//       If the input is negative, the output is close to -1.0.
+//   * Model generated with the SVM API.
+#[bench]
+fn bench_svm_sign_learner(b: &mut Bencher) {
+    // Training data
+    let inputs = Matrix::new(11, 1, vec![
+                             -0.1, -2., -9., -101., -666.7,
+                             0., 0.1, 1., 11., 99., 456.7
+                             ]);
+    let targets = Vector::new(vec![
+                              -1., -1., -1., -1., -1.,
+                              1., 1., 1., 1., 1., 1.
+                              ]);
+
+    // Trainee
+    b.iter(|| {
+        let mut svm_mod = black_box(SVM::new(HyperTan::new(100., 0.), 0.3));
+        svm_mod.train(&inputs, &targets);
+        for n in (-1000..1000).filter(|&x| x % 100 == 0) {
+            let nf = n as f64;
+            let input = Matrix::new(1, 1, vec![nf]);
+            let _ = black_box(svm_mod.predict(&input));
+        }
+    });
+}


### PR DESCRIPTION
Copied the examples and bench train/predict.
At least this is a start so we have something to compare to ...

On my system, it gives:
```
test bench_svm_sign_learner ... bench:      32,314 ns/iter (+/- 1,221)
test bench_nnet_and_gate ... bench:  31,395,040 ns/iter (+/- 1,461,709)
test bench_k_means ... bench:  12,792,701 ns/iter (+/- 4,426,994)
```
