### PR TITLE
Adding error handling to model traits

### DIFF
--- a/examples/k-means_generating_cluster.rs
+++ b/examples/k-means_generating_cluster.rs
@@ -58,16 +58,17 @@ fn main() {
     // Create a new model with 2 clusters
     let mut model = KMeansClassifier::new(2);
 
-    println!("Training the model...");
     // Train the model
-    model.train(&samples);
+    println!("Training the model...");
+    // Our train function returns a Result<(), E>
+    model.train(&samples).unwrap();
 
     let centroids = model.centroids().as_ref().unwrap();
     println!("Model Centroids:\n{:.3}", centroids);
 
     // Predict the classes and partition into
     println!("Classifying the samples...");
-    let classes = model.predict(&samples);
+    let classes = model.predict(&samples).unwrap();
     let (first, second): (Vec<usize>, Vec<usize>) = classes.data().iter().partition(|&x| *x == 0);
 
     println!("Samples closest to first centroid: {}", first.len());

--- a/examples/nnet-and_gate.rs
+++ b/examples/nnet-and_gate.rs
@@ -44,7 +44,8 @@ fn main() {
     let mut model = NeuralNet::new(layers, criterion, StochasticGD::default());
 
     println!("Training...");
-    model.train(&inputs, &targets);
+    // Our train function returns a Result<(), E>
+    model.train(&inputs, &targets).unwrap();
 
     let test_cases = vec![
         0.0, 0.0,
@@ -59,7 +60,7 @@ fn main() {
         0.0,
         ];
     let test_inputs = Matrix::new(test_cases.len() / 2, 2, test_cases);
-    let res = model.predict(&test_inputs);
+    let res = model.predict(&test_inputs).unwrap();
 
     println!("Evaluation...");
     let mut hits = 0;

--- a/examples/svm-sign_learner.rs
+++ b/examples/svm-sign_learner.rs
@@ -30,7 +30,8 @@ fn main() {
 
     // Trainee
     let mut svm_mod = SVM::new(HyperTan::new(100., 0.), 0.3);
-    svm_mod.train(&inputs, &targets);
+    // Our train function returns a Result<(), E>
+    svm_mod.train(&inputs, &targets).unwrap();
 
     println!("Evaluation...");
     let mut hits = 0;
@@ -41,7 +42,7 @@ fn main() {
     for n in (-1000..1000).filter(|&x| x % 100 == 0) {
         let nf = n as f64;
         let input = Matrix::new(1, 1, vec![nf]);
-        let out = svm_mod.predict(&input);
+        let out = svm_mod.predict(&input).unwrap();
         let res = if out[0] * nf > 0. {
             hits += 1;
             true

--- a/src/learning/dbscan.rs
+++ b/src/learning/dbscan.rs
@@ -31,12 +31,13 @@
 //!                                     -2.2, 3.1]);
 //!
 //! let mut model = DBSCAN::new(0.5, 2);
-//! model.train(&inputs);
+//! model.train(&inputs).unwrap();
 //!
 //! let clustering = model.clusters().unwrap();
 //! ```
 
-use learning::UnSupModel;
+use learning::{LearningResult, UnSupModel};
+use learning::error::{Error, ErrorKind};
 
 use linalg::{Matrix, Vector};
 use rulinalg::utils;
@@ -75,7 +76,7 @@ impl Default for DBSCAN {
 
 impl UnSupModel<Matrix<f64>, Vector<Option<usize>>> for DBSCAN {
     /// Train the classifier using input data.
-    fn train(&mut self, inputs: &Matrix<f64>) {
+    fn train(&mut self, inputs: &Matrix<f64>) -> LearningResult<()> {
         self.init_params(inputs.rows());
         let mut cluster = 0;
 
@@ -95,11 +96,13 @@ impl UnSupModel<Matrix<f64>, Vector<Option<usize>>> for DBSCAN {
         }
 
         if self.predictive {
-            self._cluster_data = Some(inputs.clone())
+            self._cluster_data = Some(inputs.clone());
         }
+
+        Ok(())
     }
 
-    fn predict(&self, inputs: &Matrix<f64>) -> Vector<Option<usize>> {
+    fn predict(&self, inputs: &Matrix<f64>) -> LearningResult<Vector<Option<usize>>> {
         if self.predictive {
             if let (&Some(ref cluster_data), &Some(ref clusters)) = (&self._cluster_data,
                                                                      &self.clusters) {
@@ -122,12 +125,13 @@ impl UnSupModel<Matrix<f64>, Vector<Option<usize>>> for DBSCAN {
                     }
                 }
 
-                Vector::new(classes)
+                Ok(Vector::new(classes))
             } else {
-                panic!("The model has not been trained.");
+                Err(Error::new(ErrorKind::UntrainedModel, "The model has not been trained."))
             }
         } else {
-            panic!("Model must be set to predictive. Use `self.set_predictive(true)`.");
+            Err(Error::new(ErrorKind::InvalidState,
+                           "Model must be set to predictive. Use `self.set_predictive(true)`."))
         }
     }
 }

--- a/src/learning/dbscan.rs
+++ b/src/learning/dbscan.rs
@@ -127,7 +127,7 @@ impl UnSupModel<Matrix<f64>, Vector<Option<usize>>> for DBSCAN {
 
                 Ok(Vector::new(classes))
             } else {
-                Err(Error::new(ErrorKind::UntrainedModel, "The model has not been trained."))
+                Err(Error::new_untrained())
             }
         } else {
             Err(Error::new(ErrorKind::InvalidState,

--- a/src/learning/error.rs
+++ b/src/learning/error.rs
@@ -40,6 +40,13 @@ impl Error {
         }
     }
 
+    /// Returns a new error for an untrained model
+    ///
+    /// This function is unstable and may be removed with changes to the API.
+    pub fn new_untrained() -> Error {
+        Error::new(ErrorKind::UntrainedModel, "The model has not been trained.")
+    }
+
     /// Get the kind of this `Error`.
     pub fn kind(&self) -> &ErrorKind {
         &self.kind

--- a/src/learning/error.rs
+++ b/src/learning/error.rs
@@ -25,6 +25,8 @@ pub enum ErrorKind {
     InvalidData,
     /// The action could not be carried out as the model was in an invalid state.
     InvalidState,
+    /// The model has not been trained
+    UntrainedModel
 }
 
 impl Error {

--- a/src/learning/glm.rs
+++ b/src/learning/glm.rs
@@ -25,11 +25,11 @@
 //! let mut log_mod = GenLinearModel::new(Bernoulli);
 //!
 //! // Train the model
-//! log_mod.train(&inputs, &targets);
+//! log_mod.train(&inputs, &targets).unwrap();
 //!
 //! // Now we'll predict a new point
 //! let new_point = Matrix::new(1,1,vec![10.]);
-//! let output = log_mod.predict(&new_point);
+//! let output = log_mod.predict(&new_point).unwrap();
 //!
 //! // Hopefully we classified our new point correctly!
 //! assert!(output[0] > 0.5, "Our classifier isn't very good!");
@@ -38,7 +38,8 @@
 use linalg::Vector;
 use linalg::Matrix;
 
-use learning::SupModel;
+use learning::{LearningResult, SupModel};
+use learning::error::{Error, ErrorKind};
 
 /// The Generalized Linear Model
 ///
@@ -78,22 +79,24 @@ impl<C: Criterion> GenLinearModel<C> {
 /// The model is trained using Iteratively Re-weighted Least Squares.
 impl<C: Criterion> SupModel<Matrix<f64>, Vector<f64>> for GenLinearModel<C> {
     /// Predict output from inputs.
-    fn predict(&self, inputs: &Matrix<f64>) -> Vector<f64> {
+    fn predict(&self, inputs: &Matrix<f64>) -> LearningResult<Vector<f64>> {
         if let Some(ref v) = self.parameters {
             let ones = Matrix::<f64>::ones(inputs.rows(), 1);
             let full_inputs = ones.hcat(inputs);
-            self.criterion.apply_link_inv(full_inputs * v)
+            Ok(self.criterion.apply_link_inv(full_inputs * v))
         } else {
-            panic!("The model has not been trained.");
+            Err(Error::new(ErrorKind::UntrainedModel, "The model has not been trained."))
         }
     }
 
     /// Train the model using inputs and targets.
-    fn train(&mut self, inputs: &Matrix<f64>, targets: &Vector<f64>) {
+    fn train(&mut self, inputs: &Matrix<f64>, targets: &Vector<f64>) -> LearningResult<()> {
         let n = inputs.rows();
 
-        assert!(n == targets.size(),
-                "Training data do not have the same dimensions.");
+        if n != targets.size() {
+            return Err(Error::new(ErrorKind::InvalidData,
+                                  "Training data do not have the same dimensions"));
+        }
 
         // Construct initial estimate for mu
         let mut mu = Vector::new(self.criterion.initialize_mu(targets.data()));
@@ -132,6 +135,7 @@ impl<C: Criterion> SupModel<Matrix<f64>, Vector<f64>> for GenLinearModel<C> {
         }
 
         self.parameters = Some(beta);
+        Ok(())
     }
 }
 

--- a/src/learning/glm.rs
+++ b/src/learning/glm.rs
@@ -85,7 +85,7 @@ impl<C: Criterion> SupModel<Matrix<f64>, Vector<f64>> for GenLinearModel<C> {
             let full_inputs = ones.hcat(inputs);
             Ok(self.criterion.apply_link_inv(full_inputs * v))
         } else {
-            Err(Error::new(ErrorKind::UntrainedModel, "The model has not been trained."))
+            Err(Error::new_untrained())
         }
     }
 

--- a/src/learning/gmm.rs
+++ b/src/learning/gmm.rs
@@ -108,7 +108,7 @@ impl UnSupModel<Matrix<f64>, Matrix<f64>> for GaussianMixtureModel {
         if let (&Some(_), &Some(_)) = (&self.model_means, &self.model_covars) {
             Ok(self.membership_weights(inputs).0)
         } else {
-            Err(Error::new(ErrorKind::UntrainedModel, "The model has not been trained."))
+            Err(Error::new_untrained())
         }
 
     }

--- a/src/learning/gp.rs
+++ b/src/learning/gp.rs
@@ -16,20 +16,23 @@
 //! let train_data = Matrix::new(10,1,vec![0.,1.,2.,3.,4.,5.,6.,7.,8.,9.]);
 //! let target = Vector::new(vec![0.,1.,2.,3.,4.,4.,3.,2.,1.,0.]);
 //!
-//! gaussp.train(&train_data, &target);
+//! gaussp.train(&train_data, &target).unwrap();
 //!
 //! let test_data = Matrix::new(5,1,vec![2.3,4.4,5.1,6.2,7.1]);
 //!
-//! let outputs = gaussp.predict(&test_data);
+//! let outputs = gaussp.predict(&test_data).unwrap();
 //! ```
 //! Alternatively one could use `gaussp.get_posterior()` which would return both
 //! the predictive mean and covariance. However, this is likely to change in
 //! a future release.
 
 use learning::toolkit::kernel::{Kernel, SquaredExp};
-use learning::SupModel;
+use learning::{LearningResult, SupModel};
+use learning::error::{Error, ErrorKind};
+
 use linalg::Matrix;
 use linalg::Vector;
+
 
 /// Trait for GP mean functions.
 pub trait MeanFunc {
@@ -127,9 +130,10 @@ impl<T: Kernel, U: MeanFunc> GaussianProcess<T, U> {
         let dim2 = m2.rows();
 
         let mut ker_data = Vec::with_capacity(dim1 * dim2);
-        ker_data.extend(
-            m1.iter_rows().flat_map(|row1| m2.iter_rows()
-                                    .map(move |row2| self.ker.kernel(row1, row2))));
+        ker_data.extend(m1.iter_rows().flat_map(|row1| {
+            m2.iter_rows()
+                .map(move |row2| self.ker.kernel(row1, row2))
+        }));
 
         Matrix::new(dim1, dim2, ker_data)
     }
@@ -137,29 +141,28 @@ impl<T: Kernel, U: MeanFunc> GaussianProcess<T, U> {
 
 impl<T: Kernel, U: MeanFunc> SupModel<Matrix<f64>, Vector<f64>> for GaussianProcess<T, U> {
     /// Predict output from inputs.
-    fn predict(&self, inputs: &Matrix<f64>) -> Vector<f64> {
+    fn predict(&self, inputs: &Matrix<f64>) -> LearningResult<Vector<f64>> {
 
         // Messy referencing for succint syntax
         if let (&Some(ref alpha), &Some(ref t_data)) = (&self.alpha, &self.train_data) {
             let mean = self.mean.func(inputs.clone());
-
             let post_mean = self.ker_mat(inputs, t_data) * alpha;
-
-            return mean + post_mean;
-
+            Ok(mean + post_mean)
+        } else {
+            Err(Error::new(ErrorKind::UntrainedModel, "The model has not been trained."))
         }
-
-        panic!("The model has not been trained.");
     }
 
     /// Train the model using data and outputs.
-    fn train(&mut self, inputs: &Matrix<f64>, targets: &Vector<f64>) {
+    fn train(&mut self, inputs: &Matrix<f64>, targets: &Vector<f64>) -> LearningResult<()> {
         let noise_mat = Matrix::identity(inputs.rows()) * self.noise;
 
         let ker_mat = self.ker_mat(inputs, inputs);
 
-        let train_mat =
-            (ker_mat + noise_mat).cholesky().expect("Could not compute Cholesky decomposition.");
+        let train_mat = try!((ker_mat + noise_mat).cholesky().map_err(|_| {
+            Error::new(ErrorKind::InvalidState,
+                       "Could not compute Cholesky decomposition.")
+        }));
 
         let x = train_mat.solve_l_triangular(targets - self.mean.func(inputs.clone())).unwrap();
         let alpha = train_mat.transpose().solve_u_triangular(x).unwrap();
@@ -167,6 +170,8 @@ impl<T: Kernel, U: MeanFunc> SupModel<Matrix<f64>, Vector<f64>> for GaussianProc
         self.train_mat = Some(train_mat);
         self.train_data = Some(inputs.clone());
         self.alpha = Some(alpha);
+
+        Ok(())
     }
 }
 

--- a/src/learning/gp.rs
+++ b/src/learning/gp.rs
@@ -207,7 +207,7 @@ impl<T: Kernel, U: MeanFunc> GaussianProcess<T, U> {
 
             Ok((post_mean, post_var))
         } else {
-            Err(Error::new(ErrorKind::UntrainedModel, "The model has not been trained."))
+            Err(Error::new_untrained())
         }
     }
 }

--- a/src/learning/k_means.rs
+++ b/src/learning/k_means.rs
@@ -86,7 +86,7 @@ impl<InitAlg: Initializer> UnSupModel<Matrix<f64>, Vector<usize>> for KMeansClas
         if let Some(ref centroids) = self.centroids {
             Ok(KMeansClassifier::<InitAlg>::find_closest_centroids(centroids.as_slice(), inputs).0)
         } else {
-            Err(Error::new(ErrorKind::UntrainedModel, "The model has not been trained."))
+            Err(Error::new_untrained())
         }
     }
 

--- a/src/learning/lin_reg.rs
+++ b/src/learning/lin_reg.rs
@@ -35,7 +35,7 @@ use learning::toolkit::cost_fn::CostFunc;
 use learning::toolkit::cost_fn::MeanSqError;
 use learning::optim::grad_desc::GradientDesc;
 use learning::optim::{OptimAlgorithm, Optimizable};
-use learning::error::{Error, ErrorKind};
+use learning::error::Error;
 
 use linalg::Matrix;
 use linalg::Vector;
@@ -105,7 +105,7 @@ impl SupModel<Matrix<f64>, Vector<f64>> for LinRegressor {
             let full_inputs = ones.hcat(inputs);
             Ok(full_inputs * v)
         } else {
-            Err(Error::new(ErrorKind::UntrainedModel, "The model has not been trained."))
+            Err(Error::new_untrained())
         }
     }
 }

--- a/src/learning/lin_reg.rs
+++ b/src/learning/lin_reg.rs
@@ -20,24 +20,25 @@
 //! let mut lin_mod = LinRegressor::default();
 //!
 //! // Train the model
-//! lin_mod.train(&inputs, &targets);
+//! lin_mod.train(&inputs, &targets).unwrap();
 //!
 //! // Now we'll predict a new point
 //! let new_point = Matrix::new(1,1,vec![10.]);
-//! let output = lin_mod.predict(&new_point);
+//! let output = lin_mod.predict(&new_point).unwrap();
 //!
 //! // Hopefully we classified our new point correctly!
 //! assert!(output[0] > 17f64, "Our regressor isn't very good!");
 //! ```
 
-use learning::SupModel;
-use linalg::Matrix;
-use linalg::Vector;
+use learning::{LearningResult, SupModel};
 use learning::toolkit::cost_fn::CostFunc;
 use learning::toolkit::cost_fn::MeanSqError;
 use learning::optim::grad_desc::GradientDesc;
-use learning::optim::OptimAlgorithm;
-use learning::optim::Optimizable;
+use learning::optim::{OptimAlgorithm, Optimizable};
+use learning::error::{Error, ErrorKind};
+
+use linalg::Matrix;
+use linalg::Vector;
 
 /// Linear Regression Model.
 ///
@@ -80,9 +81,9 @@ impl SupModel<Matrix<f64>, Vector<f64>> for LinRegressor {
     /// let inputs = Matrix::new(3,1, vec![2.0, 3.0, 4.0]);
     /// let targets = Vector::new(vec![5.0, 6.0, 7.0]);
     ///
-    /// lin_mod.train(&inputs, &targets);
+    /// lin_mod.train(&inputs, &targets).unwrap();
     /// ```
-    fn train(&mut self, inputs: &Matrix<f64>, targets: &Vector<f64>) {
+    fn train(&mut self, inputs: &Matrix<f64>, targets: &Vector<f64>) -> LearningResult<()> {
         let ones = Matrix::<f64>::ones(inputs.rows(), 1);
         let full_inputs = ones.hcat(inputs);
 
@@ -91,18 +92,20 @@ impl SupModel<Matrix<f64>, Vector<f64>> for LinRegressor {
         self.parameters =
             Some(((&xt * full_inputs).inverse().expect("Could not compute (X_T X) inverse.") *
                   &xt) * targets);
+
+        Ok(())
     }
 
     /// Predict output value from input data.
     ///
     /// Model must be trained before prediction can be made.
-    fn predict(&self, inputs: &Matrix<f64>) -> Vector<f64> {
+    fn predict(&self, inputs: &Matrix<f64>) -> LearningResult<Vector<f64>> {
         if let Some(ref v) = self.parameters {
             let ones = Matrix::<f64>::ones(inputs.rows(), 1);
             let full_inputs = ones.hcat(inputs);
-            full_inputs * v
+            Ok(full_inputs * v)
         } else {
-            panic!("Model has not been trained.");
+            Err(Error::new(ErrorKind::UntrainedModel, "The model has not been trained."))
         }
     }
 }
@@ -148,7 +151,7 @@ impl LinRegressor {
     ///
     /// // Now we'll predict a new point
     /// let new_point = Matrix::new(1,1,vec![10.]);
-    /// let _ = lin_mod.predict(&new_point);
+    /// let _ = lin_mod.predict(&new_point).unwrap();
     /// ```
     pub fn train_with_optimization(&mut self, inputs: &Matrix<f64>, targets: &Vector<f64>) {
         let ones = Matrix::<f64>::ones(inputs.rows(), 1);

--- a/src/learning/logistic_reg.rs
+++ b/src/learning/logistic_reg.rs
@@ -20,11 +20,11 @@
 //! let mut log_mod = LogisticRegressor::default();
 //!
 //! // Train the model
-//! log_mod.train(&inputs, &targets);
+//! log_mod.train(&inputs, &targets).unwrap();
 //!
 //! // Now we'll predict a new point
 //! let new_point = Matrix::new(1,1,vec![10.]);
-//! let output = log_mod.predict(&new_point);
+//! let output = log_mod.predict(&new_point).unwrap();
 //!
 //! // Hopefully we classified our new point correctly!
 //! assert!(output[0] > 0.5, "Our classifier isn't very good!");
@@ -34,13 +34,15 @@
 //! by using the `new` constructor instead. This allows us to provide
 //! a `GradientDesc` object with custom parameters.
 
-use learning::SupModel;
-use linalg::Matrix;
-use linalg::Vector;
+use learning::{LearningResult, SupModel};
 use learning::toolkit::activ_fn::{ActivationFunc, Sigmoid};
 use learning::toolkit::cost_fn::{CostFunc, CrossEntropyError};
 use learning::optim::grad_desc::GradientDesc;
 use learning::optim::{OptimAlgorithm, Optimizable};
+use learning::error::{Error, ErrorKind};
+
+use linalg::Matrix;
+use linalg::Vector;
 
 /// Logistic Regression Model.
 ///
@@ -110,9 +112,9 @@ impl<A> SupModel<Matrix<f64>, Vector<f64>> for LogisticRegressor<A>
     /// let inputs = Matrix::new(3,2, vec![1.0, 2.0, 1.0, 3.0, 1.0, 4.0]);
     /// let targets = Vector::new(vec![5.0, 6.0, 7.0]);
     ///
-    /// logistic_mod.train(&inputs, &targets);
+    /// logistic_mod.train(&inputs, &targets).unwrap();
     /// ```
-    fn train(&mut self, inputs: &Matrix<f64>, targets: &Vector<f64>) {
+    fn train(&mut self, inputs: &Matrix<f64>, targets: &Vector<f64>) -> LearningResult<()> {
         let ones = Matrix::<f64>::ones(inputs.rows(), 1);
         let full_inputs = ones.hcat(inputs);
 
@@ -120,18 +122,19 @@ impl<A> SupModel<Matrix<f64>, Vector<f64>> for LogisticRegressor<A>
 
         let optimal_w = self.alg.optimize(&self.base, &initial_params[..], &full_inputs, targets);
         self.base.set_parameters(Vector::new(optimal_w));
+        Ok(())
     }
 
     /// Predict output value from input data.
     ///
     /// Model must be trained before prediction can be made.
-    fn predict(&self, inputs: &Matrix<f64>) -> Vector<f64> {
+    fn predict(&self, inputs: &Matrix<f64>) -> LearningResult<Vector<f64>> {
         if let Some(v) = self.base.parameters() {
             let ones = Matrix::<f64>::ones(inputs.rows(), 1);
             let full_inputs = ones.hcat(inputs);
-            (full_inputs * v).apply(&Sigmoid::func)
+            Ok((full_inputs * v).apply(&Sigmoid::func))
         } else {
-            panic!("Model has not been trained.");
+            Err(Error::new(ErrorKind::UntrainedModel, "The model has not been trained."))
         }
     }
 }

--- a/src/learning/logistic_reg.rs
+++ b/src/learning/logistic_reg.rs
@@ -39,7 +39,7 @@ use learning::toolkit::activ_fn::{ActivationFunc, Sigmoid};
 use learning::toolkit::cost_fn::{CostFunc, CrossEntropyError};
 use learning::optim::grad_desc::GradientDesc;
 use learning::optim::{OptimAlgorithm, Optimizable};
-use learning::error::{Error, ErrorKind};
+use learning::error::Error;
 
 use linalg::Matrix;
 use linalg::Vector;
@@ -134,7 +134,7 @@ impl<A> SupModel<Matrix<f64>, Vector<f64>> for LogisticRegressor<A>
             let full_inputs = ones.hcat(inputs);
             Ok((full_inputs * v).apply(&Sigmoid::func))
         } else {
-            Err(Error::new(ErrorKind::UntrainedModel, "The model has not been trained."))
+            Err(Error::new_untrained())
         }
     }
 }

--- a/src/learning/naive_bayes.rs
+++ b/src/learning/naive_bayes.rs
@@ -142,7 +142,7 @@ impl<T: Distribution> NaiveBayes<T> {
             // Get the joint log likelihood from the distribution
             Ok(distr.joint_log_lik(inputs, prior))
         } else {
-            Err(Error::new(ErrorKind::UntrainedModel, "The model has not been trained."))
+            Err(Error::new_untrained())
         }
     }
 

--- a/src/learning/svm.rs
+++ b/src/learning/svm.rs
@@ -22,11 +22,11 @@
 //! let mut svm_mod = SVM::default();
 //!
 //! // Train the model
-//! svm_mod.train(&inputs, &targets);
+//! svm_mod.train(&inputs, &targets).unwrap();
 //!
 //! // Now we'll predict a new point
 //! let new_point = Matrix::new(1,1,vec![10.]);
-//! let output = svm_mod.predict(&new_point);
+//! let output = svm_mod.predict(&new_point).unwrap();
 //!
 //! // Hopefully we classified our new point correctly!
 //! assert!(output[0] == 1f64, "Our classifier isn't very good!");
@@ -37,7 +37,8 @@ use linalg::Matrix;
 use linalg::Vector;
 
 use learning::toolkit::kernel::{Kernel, SquaredExp};
-use learning::SupModel;
+use learning::{LearningResult, SupModel};
+use learning::error::{Error, ErrorKind};
 
 use rand;
 use rand::Rng;
@@ -109,9 +110,10 @@ impl<K: Kernel> SVM<K> {
 
         let mut ker_data = Vec::with_capacity(dim1 * dim2);
 
-        ker_data.extend(
-            m1.iter_rows().flat_map(|row1| m2.iter_rows()
-                                    .map(move |row2| self.ker.kernel(row1, row2))));
+        ker_data.extend(m1.iter_rows().flat_map(|row1| {
+            m2.iter_rows()
+                .map(move |row2| self.ker.kernel(row1, row2))
+        }));
 
         Matrix::new(dim1, dim2, ker_data)
     }
@@ -120,7 +122,7 @@ impl<K: Kernel> SVM<K> {
 /// Train the model using the Pegasos algorithm and
 /// predict the model output from new data.
 impl<K: Kernel> SupModel<Matrix<f64>, Vector<f64>> for SVM<K> {
-    fn predict(&self, inputs: &Matrix<f64>) -> Vector<f64> {
+    fn predict(&self, inputs: &Matrix<f64>) -> LearningResult<Vector<f64>> {
         let ones = Matrix::<f64>::ones(inputs.rows(), 1);
         let full_inputs = ones.hcat(inputs);
 
@@ -131,13 +133,13 @@ impl<K: Kernel> SupModel<Matrix<f64>, Vector<f64>> for SVM<K> {
 
             let plane_dist = ker_mat * weight_vec;
 
-            plane_dist.apply(&|d| d.signum())
+            Ok(plane_dist.apply(&|d| d.signum()))
         } else {
-            panic!("Model has not been trained.");
+            Err(Error::new(ErrorKind::UntrainedModel, "The model has not been trained."))
         }
     }
 
-    fn train(&mut self, inputs: &Matrix<f64>, targets: &Vector<f64>) {
+    fn train(&mut self, inputs: &Matrix<f64>, targets: &Vector<f64>) -> LearningResult<()> {
         let n = inputs.rows();
 
         let mut rng = rand::thread_rng();
@@ -150,9 +152,9 @@ impl<K: Kernel> SupModel<Matrix<f64>, Vector<f64>> for SVM<K> {
         for t in 0..self.optim_iters {
             let i = rng.gen_range(0, n);
             let row_i = full_inputs.select_rows(&[i]);
-            let sum =  full_inputs.iter_rows()
-                .fold(0f64, |sum, row| sum + self.ker.kernel(row_i.data(), row)) * 
-                targets[i] / (self.lambda * (t as f64));
+            let sum = full_inputs.iter_rows()
+                .fold(0f64, |sum, row| sum + self.ker.kernel(row_i.data(), row)) *
+                      targets[i] / (self.lambda * (t as f64));
 
             if sum < 1f64 {
                 alpha[i] += 1f64;
@@ -162,5 +164,7 @@ impl<K: Kernel> SupModel<Matrix<f64>, Vector<f64>> for SVM<K> {
         self.alpha = Some(Vector::new(alpha) / (self.optim_iters as f64));
         self.train_inputs = Some(full_inputs);
         self.train_targets = Some(targets.clone());
+
+        Ok(())
     }
 }

--- a/src/learning/svm.rs
+++ b/src/learning/svm.rs
@@ -137,7 +137,7 @@ impl<K: Kernel> SupModel<Matrix<f64>, Vector<f64>> for SVM<K> {
 
             Ok(plane_dist.apply(&|d| d.signum()))
         } else {
-            Err(Error::new(ErrorKind::UntrainedModel, "The model has not been trained."))
+            Err(Error::new_untrained())
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,10 +83,10 @@
 //! // Now we can train and predict from the model.
 //!
 //! // Train the model!
-//! gp.train(&inputs, &targets);
+//! gp.train(&inputs, &targets).unwrap();
 //!
 //! // Predict output from test datae]
-//! let outputs = gp.predict(&test_inputs);
+//! let outputs = gp.predict(&test_inputs).unwrap();
 //! ```
 //!
 //! This code could have been a lot simpler if we had simply adopted
@@ -109,7 +109,7 @@ extern crate rulinalg;
 extern crate num as libnum;
 extern crate rand;
 
-pub mod prelude;
+pub mod prelude; 
 
 /// The linear algebra module
 ///
@@ -141,22 +141,25 @@ pub mod learning {
 
     pub mod error;
 
+    /// A new type which provides clean access to the learning errors
+    pub type LearningResult<T> = Result<T, error::Error>;
+
     /// Trait for supervised model.
     pub trait SupModel<T, U> {
         /// Predict output from inputs.
-        fn predict(&self, inputs: &T) -> U;
+        fn predict(&self, inputs: &T) -> LearningResult<U>;
 
         /// Train the model using inputs and targets.
-        fn train(&mut self, inputs: &T, targets: &U);
+        fn train(&mut self, inputs: &T, targets: &U) -> LearningResult<()>;
     }
 
     /// Trait for unsupervised model.
     pub trait UnSupModel<T, U> {
         /// Predict output from inputs.
-        fn predict(&self, inputs: &T) -> U;
+        fn predict(&self, inputs: &T) -> LearningResult<U>;
 
         /// Train the model using inputs.
-        fn train(&mut self, inputs: &T);
+        fn train(&mut self, inputs: &T) -> LearningResult<()>;
     }
 
     /// Module for optimization in machine learning setting.

--- a/tests/learning/dbscan.rs
+++ b/tests/learning/dbscan.rs
@@ -13,7 +13,7 @@ fn test_basic_clusters() {
                                         -2.2, 3.1]);
 
     let mut model = DBSCAN::new(0.5, 2);
-    model.train(&inputs);
+    model.train(&inputs).unwrap();
 
     let clustering = model.clusters().unwrap();
 
@@ -33,11 +33,11 @@ fn test_basic_prediction() {
 
     let mut model = DBSCAN::new(0.5, 2);
     model.set_predictive(true);
-    model.train(&inputs);
+    model.train(&inputs).unwrap();
 
     let new_points = Matrix::new(2,2, vec![1.0, 2.0, 4.0, 4.0]);
 
-    let classes = model.predict(&new_points);
+    let classes = model.predict(&new_points).unwrap();
     assert!(classes[0] == Some(0));
     assert!(classes[1] == None);
 }

--- a/tests/learning/gp.rs
+++ b/tests/learning/gp.rs
@@ -11,9 +11,9 @@ fn test_default_gp() {
 	let inputs = Matrix::new(10,1,vec![0.,1.,2.,3.,4.,5.,6.,7.,8.,9.]);
 	let targets = Vector::new(vec![0.,1.,2.,3.,4.,4.,3.,2.,1.,0.]);
 
-	gp.train(&inputs, &targets);
+	gp.train(&inputs, &targets).unwrap();
 
 	let test_inputs = Matrix::new(5,1,vec![2.3,4.4,5.1,6.2,7.1]);
 
-	let _outputs = gp.predict(&test_inputs);
+	let _outputs = gp.predict(&test_inputs).unwrap();
 }

--- a/tests/learning/k_means.rs
+++ b/tests/learning/k_means.rs
@@ -9,9 +9,9 @@ fn test_model_default() {
     let inputs = Matrix::new(3, 2, vec![1.0, 2.0, 1.0, 3.0, 1.0, 4.0]);
     let targets = Matrix::new(3,2, vec![1.0, 2.0, 1.0, 3.0, 1.0, 4.0]);
 
-    model.train(&inputs);
+    model.train(&inputs).unwrap();
 
-    let outputs = model.predict(&targets);
+    let outputs = model.predict(&targets).unwrap();
 
     assert_eq!(outputs.size(), 3);
 }
@@ -23,9 +23,9 @@ fn test_model_iter() {
     let targets = Matrix::new(3,2, vec![1.0, 2.0, 1.0, 3.0, 1.0, 4.0]);
 
     model.set_iters(1000);
-    model.train(&inputs);
+    model.train(&inputs).unwrap();
 
-    let outputs = model.predict(&targets);
+    let outputs = model.predict(&targets).unwrap();
 
     assert_eq!(outputs.size(), 3);
 }
@@ -36,9 +36,9 @@ fn test_model_forgy() {
     let inputs = Matrix::new(3, 2, vec![1.0, 2.0, 1.0, 3.0, 1.0, 4.0]);
     let targets = Matrix::new(3,2, vec![1.0, 2.0, 1.0, 3.0, 1.0, 4.0]);
 
-    model.train(&inputs);
+    model.train(&inputs).unwrap();
 
-    let outputs = model.predict(&targets);
+    let outputs = model.predict(&targets).unwrap();
 
     assert_eq!(outputs.size(), 3);
 }
@@ -49,9 +49,9 @@ fn test_model_ran_partition() {
     let inputs = Matrix::new(3, 2, vec![1.0, 2.0, 1.0, 3.0, 1.0, 4.0]);
     let targets = Matrix::new(3,2, vec![1.0, 2.0, 1.0, 3.0, 1.0, 4.0]);
 
-    model.train(&inputs);
+    model.train(&inputs).unwrap();
 
-    let outputs = model.predict(&targets);
+    let outputs = model.predict(&targets).unwrap();
 
     assert_eq!(outputs.size(), 3);
 }
@@ -62,9 +62,9 @@ fn test_model_kplusplus() {
     let inputs = Matrix::new(3, 2, vec![1.0, 2.0, 1.0, 3.0, 1.0, 4.0]);
     let targets = Matrix::new(3,2, vec![1.0, 2.0, 1.0, 3.0, 1.0, 4.0]);
 
-    model.train(&inputs);
+    model.train(&inputs).unwrap();
 
-    let outputs = model.predict(&targets);
+    let outputs = model.predict(&targets).unwrap();
 
     assert_eq!(outputs.size(), 3);
 }
@@ -75,7 +75,7 @@ fn test_no_train_predict() {
     let model = KMeansClassifier::<KPlusPlus>::new(3);
     let inputs = Matrix::new(3, 2, vec![1.0, 2.0, 1.0, 3.0, 1.0, 4.0]);
 
-    model.predict(&inputs);
+    model.predict(&inputs).unwrap();
 
 }
 
@@ -89,9 +89,9 @@ fn test_two_centroids() {
                                         314.59375, 174.6875,
                                         350.59375, 161.6875]);
 
-    model.train(&inputs);
+    model.train(&inputs).unwrap();
 
-    let classes = model.predict(&inputs);
+    let classes = model.predict(&inputs).unwrap();
     let class_a = classes[0];
 
     let class_b = if class_a == 0 { 1 } else { 0 };

--- a/tests/learning/lin_reg.rs
+++ b/tests/learning/lin_reg.rs
@@ -21,7 +21,7 @@ fn test_regression() {
     let inputs = Matrix::new(3, 1, vec![2.0, 3.0, 4.0]);
     let targets = Vector::new(vec![5.0, 6.0, 7.0]);
 
-    lin_mod.train(&inputs, &targets);
+    lin_mod.train(&inputs, &targets).unwrap();
 
     let parameters = lin_mod.parameters().unwrap();
 
@@ -46,5 +46,5 @@ fn test_no_train_predict() {
     let lin_mod = LinRegressor::default();
     let inputs = Matrix::new(3, 2, vec![1.0, 2.0, 1.0, 3.0, 1.0, 4.0]);
 
-    let _ = lin_mod.predict(&inputs);
+    let _ = lin_mod.predict(&inputs).unwrap();
 }


### PR DESCRIPTION
This PR adds some error handling to the `SupModel` and `UnSupModel` traits. It's flagged as WIP as I have a few tweaks planned - but the core content is ready for review and I'd appreciate some feedback.

Note that I haven't attempted to cover all possible panics from within the `train` and `predict` functions. I think it is non-trivial to decide when such things should occur and so I'd prefer to take a lightweight approach for now and add them in as we go (as this will not cause breakage in the api). With that said - if you see something that should be returning an `Error` here please comment so I can address/create an issue.