### PR TITLE
don't hide `stats` module behind feature flag?

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -207,7 +207,6 @@ pub mod learning {
     }
 }
 
-#[cfg(feature = "stats")]
 /// Module for computational statistics
 pub mod stats {
 


### PR DESCRIPTION
This got in my way (first was puzzled by the compiler insisting it doesn't exist despite it being documented, then later wasn't aware and still am not aware of how to specify a feature with `cargo run --example`). Unless there's a specific rationale (saving compile time?), it may be more convenient to just make it a first-class part of library.
