### PR TITLE
Updating to Rulinalg 0.3.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ stats = []
 [dependencies]
 num = { version = "0.1.34", default-features = false }
 rand = "0.3.14"
-rulinalg = "0.3.0"
+rulinalg = "0.3.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,4 @@ stats = []
 [dependencies]
 num = { version = "0.1.34", default-features = false }
 rand = "0.3.14"
-rulinalg = "0.2.1"
+rulinalg = "0.3.0"

--- a/benches/examples/k_means.rs
+++ b/benches/examples/k_means.rs
@@ -1,4 +1,4 @@
-use rusty_machine::linalg::Matrix;
+use rusty_machine::linalg::{Matrix, BaseMatrix};
 use rusty_machine::learning::k_means::KMeansClassifier;
 use rusty_machine::learning::UnSupModel;
 

--- a/examples/k-means_generating_cluster.rs
+++ b/examples/k-means_generating_cluster.rs
@@ -1,7 +1,7 @@
 extern crate rusty_machine;
 extern crate rand;
 
-use rusty_machine::linalg::Matrix;
+use rusty_machine::linalg::{Matrix, BaseMatrix};
 use rusty_machine::learning::k_means::KMeansClassifier;
 use rusty_machine::learning::UnSupModel;
 

--- a/src/data/transforms/minmax.rs
+++ b/src/data/transforms/minmax.rs
@@ -25,7 +25,7 @@
 //! ```
 
 use learning::error::{Error, ErrorKind};
-use linalg::Matrix;
+use linalg::{Matrix, BaseMatrix, BaseMatrixMut};
 use super::Transformer;
 
 use rulinalg::utils;

--- a/src/data/transforms/standardize.rs
+++ b/src/data/transforms/standardize.rs
@@ -25,7 +25,7 @@
 //! ```
 
 use learning::error::{Error, ErrorKind};
-use linalg::{Matrix, Vector, Axes};
+use linalg::{Matrix, Vector, Axes, BaseMatrix, BaseMatrixMut};
 use super::Transformer;
 
 use rulinalg::utils;

--- a/src/data/transforms/standardize.rs
+++ b/src/data/transforms/standardize.rs
@@ -93,7 +93,9 @@ impl<T: Float + FromPrimitive> Transformer<Matrix<T>> for Standardizer<T> {
                            "Cannot standardize data with only one row."))
         } else {
             let mean = inputs.mean(Axes::Row);
-            let variance = inputs.variance(Axes::Row).unwrap();
+            let variance = try!(inputs.variance(Axes::Row).map_err(|_| {
+                Error::new(ErrorKind::InvalidData, "Cannot compute variance of data.")
+            }));
 
             if mean.data().iter().any(|x| !x.is_finite()) {
                 return Err(Error::new(ErrorKind::InvalidData, "Some data point is non-finite."));

--- a/src/learning/dbscan.rs
+++ b/src/learning/dbscan.rs
@@ -38,7 +38,7 @@
 
 use learning::UnSupModel;
 
-use linalg::{Matrix, Vector};
+use linalg::{Matrix, Vector, BaseMatrix};
 use rulinalg::utils;
 
 /// DBSCAN Model

--- a/src/learning/glm.rs
+++ b/src/learning/glm.rs
@@ -36,7 +36,7 @@
 //! ```
 
 use linalg::Vector;
-use linalg::Matrix;
+use linalg::{Matrix, BaseMatrix};
 
 use learning::SupModel;
 

--- a/src/learning/gmm.rs
+++ b/src/learning/gmm.rs
@@ -31,7 +31,7 @@
 //! println!("{:?}", post_probs.data());
 //! ```
 
-use linalg::{Matrix, MatrixSlice, Vector};
+use linalg::{Matrix, MatrixSlice, Vector, BaseMatrix, BaseMatrixMut};
 use rulinalg::utils;
 
 use learning::UnSupModel;

--- a/src/learning/gp.rs
+++ b/src/learning/gp.rs
@@ -28,7 +28,7 @@
 
 use learning::toolkit::kernel::{Kernel, SquaredExp};
 use learning::SupModel;
-use linalg::Matrix;
+use linalg::{Matrix, BaseMatrix};
 use linalg::Vector;
 
 /// Trait for GP mean functions.

--- a/src/learning/k_means.rs
+++ b/src/learning/k_means.rs
@@ -42,9 +42,7 @@
 //!
 //! The [k-means++](https://en.wikipedia.org/wiki/K-means%2B%2B) scheme.
 
-use linalg::BaseSlice;
-use linalg::{Matrix, MatrixSlice, Axes};
-use linalg::Vector;
+use linalg::{Matrix, MatrixSlice, Axes, Vector, BaseMatrix};
 use learning::UnSupModel;
 use learning::error::{Error, ErrorKind};
 

--- a/src/learning/lin_reg.rs
+++ b/src/learning/lin_reg.rs
@@ -31,7 +31,7 @@
 //! ```
 
 use learning::SupModel;
-use linalg::Matrix;
+use linalg::{Matrix, BaseMatrix};
 use linalg::Vector;
 use learning::toolkit::cost_fn::CostFunc;
 use learning::toolkit::cost_fn::MeanSqError;

--- a/src/learning/logistic_reg.rs
+++ b/src/learning/logistic_reg.rs
@@ -35,7 +35,7 @@
 //! a `GradientDesc` object with custom parameters.
 
 use learning::SupModel;
-use linalg::Matrix;
+use linalg::{Matrix, BaseMatrix};
 use linalg::Vector;
 use learning::toolkit::activ_fn::{ActivationFunc, Sigmoid};
 use learning::toolkit::cost_fn::{CostFunc, CrossEntropyError};

--- a/src/learning/naive_bayes.rs
+++ b/src/learning/naive_bayes.rs
@@ -40,7 +40,7 @@
 //! println!("Final outputs --\n{}", outputs);
 //! ```
 
-use linalg::{Matrix, Axes};
+use linalg::{Matrix, Axes, BaseMatrix, BaseMatrixMut};
 use rulinalg::utils;
 use learning::SupModel;
 

--- a/src/learning/naive_bayes.rs
+++ b/src/learning/naive_bayes.rs
@@ -281,7 +281,10 @@ impl Distribution for Gaussian {
         Ok(())
     }
 
-    fn joint_log_lik(&self, data: &Matrix<f64>, class_prior: &[f64]) -> LearningResult<Matrix<f64>> {
+    fn joint_log_lik(&self,
+                     data: &Matrix<f64>,
+                     class_prior: &[f64])
+                     -> LearningResult<Matrix<f64>> {
         let class_count = class_prior.len();
         let mut log_lik = Vec::with_capacity(class_count);
 
@@ -350,7 +353,10 @@ impl Distribution for Bernoulli {
 
     }
 
-    fn joint_log_lik(&self, data: &Matrix<f64>, class_prior: &[f64]) -> LearningResult<Matrix<f64>> {
+    fn joint_log_lik(&self,
+                     data: &Matrix<f64>,
+                     class_prior: &[f64])
+                     -> LearningResult<Matrix<f64>> {
         let class_count = class_prior.len();
 
         let neg_prob = self.log_probs.clone().apply(&|x| (1f64 - x.exp()).ln());
@@ -418,7 +424,10 @@ impl Distribution for Multinomial {
         Ok(())
     }
 
-    fn joint_log_lik(&self, data: &Matrix<f64>, class_prior: &[f64]) -> LearningResult<Matrix<f64>> {
+    fn joint_log_lik(&self,
+                     data: &Matrix<f64>,
+                     class_prior: &[f64])
+                     -> LearningResult<Matrix<f64>> {
         let class_count = class_prior.len();
 
         let res = data * self.log_probs.transpose();

--- a/src/learning/nnet.rs
+++ b/src/learning/nnet.rs
@@ -41,8 +41,7 @@
 //! You can define your own criterion by implementing the `Criterion`
 //! trait with a concrete `ActivationFunc` and `CostFunc`.
 
-use linalg::{Matrix, MatrixSlice};
-use linalg::BaseSlice;
+use linalg::{Matrix, MatrixSlice, BaseMatrix, BaseMatrixMut};
 
 use learning::SupModel;
 use learning::toolkit::activ_fn;
@@ -147,7 +146,7 @@ impl<'a, T, A> NeuralNet<'a, T, A>
     /// # Examples
     ///
     /// ```
-    /// use rusty_machine::linalg::BaseSlice;
+    /// use rusty_machine::linalg::BaseMatrix;
     /// use rusty_machine::learning::nnet::NeuralNet;
     ///
     /// // Create a neural net with 4 layers, 3 neurons in each.

--- a/src/learning/optim/grad_desc.rs
+++ b/src/learning/optim/grad_desc.rs
@@ -10,7 +10,7 @@
 
 use learning::optim::{Optimizable, OptimAlgorithm};
 use linalg::Vector;
-use linalg::Matrix;
+use linalg::{Matrix, BaseMatrix};
 use rulinalg::utils;
 
 use learning::toolkit::rand_utils;

--- a/src/learning/svm.rs
+++ b/src/learning/svm.rs
@@ -33,7 +33,7 @@
 //! ```
 
 
-use linalg::Matrix;
+use linalg::{Matrix, BaseMatrix};
 use linalg::Vector;
 
 use learning::toolkit::kernel::{Kernel, SquaredExp};

--- a/src/learning/toolkit/cost_fn.rs
+++ b/src/learning/toolkit/cost_fn.rs
@@ -8,7 +8,7 @@
 //! You can also create your own custom cost functions for use in your models.
 //! Just create a struct implementing the `CostFunc` trait.
 
-use linalg::Matrix;
+use linalg::{Matrix, BaseMatrix, BaseMatrixMut};
 use linalg::Vector;
 
 /// Trait for cost functions in models.

--- a/src/learning/toolkit/regularization.rs
+++ b/src/learning/toolkit/regularization.rs
@@ -15,8 +15,7 @@
 //! ```
 
 use linalg::Metric;
-use linalg::{Matrix, MatrixSlice};
-use linalg::BaseSlice;
+use linalg::{Matrix, MatrixSlice, BaseMatrix};
 use libnum::{FromPrimitive, Float};
 
 /// Model Regularization
@@ -90,7 +89,7 @@ impl<T: Float + FromPrimitive> Regularization<T> {
 #[cfg(test)]
 mod tests {
     use super::Regularization;
-    use linalg::Matrix;
+    use linalg::{Matrix, BaseMatrix};
     use linalg::Metric;
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,8 +115,7 @@ pub mod prelude;
 ///
 /// This module contains reexports of common tools from the rulinalg crate.
 pub mod linalg {
-    pub use rulinalg::matrix::{Axes, Matrix, MatrixSlice, MatrixSliceMut};
-    pub use rulinalg::matrix::slice::BaseSlice;
+    pub use rulinalg::matrix::{Axes, Matrix, MatrixSlice, MatrixSliceMut, BaseMatrix, BaseMatrixMut};
     pub use rulinalg::vector::Vector;
     pub use rulinalg::Metric;
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -2,9 +2,8 @@
 //!
 //! This module alleviates some common imports used within rusty-machine.
 
-pub use linalg::{Matrix, MatrixSlice, MatrixSliceMut};
+pub use linalg::{Matrix, MatrixSlice, MatrixSliceMut, BaseMatrix, BaseMatrixMut};
 pub use linalg::Vector;
-pub use linalg::BaseSlice;
 pub use linalg::Axes;
 
 pub use learning::SupModel;


### PR DESCRIPTION
This will resolve PR #117 .

This continues the great work by @tafia by taking into account new breaking changes from both rusty-machine ( #120 ) and rulinalg (variance returns result).

The changes are mostly minor - modifying imports. There are some structural changes to naive bayes to help error propagation. There is also a performance regression on the neural nets but this has been discussed in #117 . The short of it is:

- `apply` is less efficient but there is an issue on rulinalg.
- `hcat` is less efficient on narrow matrices (as in the example) but more efficient on wide ones.

We are also making modifications to the neural nets with #126 which will provide big performance gains.