### PR TITLE
Adding an information criterion to the gmm module for dynamic K optimisation

### DIFF
--- a/src/learning/gmm.rs
+++ b/src/learning/gmm.rs
@@ -158,7 +158,7 @@ impl GaussianMixtureModel {
             model_means: None,
             model_covars: None,
             log_lik: 0f64,
-            bic: 0f64,
+            bic: 1f64,
             max_iters: 100,
             cov_option: CovOption::Full,
         }
@@ -201,7 +201,7 @@ impl GaussianMixtureModel {
                 model_means: None,
                 model_covars: None,
                 log_lik: 0f64,
-                bic: 0f64,
+                bic: 1f64,
                 max_iters: 100,
                 cov_option: CovOption::Full,
             })
@@ -393,7 +393,7 @@ mod tests {
     fn test_bic_none() {
         let mut model = GaussianMixtureModel::new(5);
 
-        assert_eq!(model.bic(), 0f64);
+        assert_eq!(model.bic(), 1f64);
     }
 
     #[test]

--- a/src/learning/toolkit/rand_utils.rs
+++ b/src/learning/toolkit/rand_utils.rs
@@ -3,7 +3,7 @@
 //! This module provides sampling and shuffling which are used
 //! within the learning modules.
 
-use rand::{Rng, thread_rng};
+use rand::{Rng, thread_rng, StdRng, SeedableRng};
 
 /// ```
 /// use rusty_machine::learning::toolkit::rand_utils;
@@ -37,6 +37,41 @@ pub fn reservoir_sample<T: Copy>(pool: &[T], reservoir_size: usize) -> Vec<T> {
         }
     }
 
+    res
+}
+
+///Uses a user defined StdRng generator, allowing seeded PRNG.
+/// ```
+/// use rand::{Rng, SeedableRng, StdRng};
+/// use rusty_machine::learning::toolkit::rand_utils;
+/// let seed: [_] = [1,2,3,4,5];
+/// let mut pool = &mut [1,2,3,4];
+/// let sample = rand_utils::reservoir_sample(pool, 3, seed);
+///
+/// println!("{:?}", sample);
+/// ```
+pub fn reservoir_sample_custom<T: Copy>(pool: &[T], reservoir_size: usize, seed: &[usize]) -> Vec<T> {
+    assert!(pool.len() >= reservoir_size,
+            "Sample size is greater than total.");
+
+    let mut pool_mut = &pool[..];
+
+    let mut res = pool_mut[..reservoir_size].to_vec();
+    pool_mut = &pool_mut[reservoir_size..];
+
+    let mut ele_seen = reservoir_size;
+    let mut rng: StdRng = SeedableRng::from_seed(seed);
+    while pool_mut.len() > 0 {
+        ele_seen += 1;
+        let r = rng.gen_range(0, ele_seen);
+
+        let p_0 = pool_mut[0];
+        pool_mut = &pool_mut[1..];
+
+        if r < reservoir_size {
+            res[r] = p_0;
+        }
+    }
     res
 }
 


### PR DESCRIPTION
If you want to optimise for K in a cluster model (aka by discovering an optimal fit and to prevent overfitting), you need access to information about the performance of the model.

Right now neither the gaussian mixture model or k-means modules provide direct access to an interface to the fit performance, normally provided as the `log likelihood`.

It definitely is valuable to restrict public access to the interface as much as possible. I don't think the log likelihood itself is a meaningful value and should be encapsulated in the event of internal refactoring, so I implemented the [Bayesian Information Criterion BIC)](https://en.wikipedia.org/wiki/Bayesian_information_criterion) for the gmm module.

One major caveat of the BIC is that for the equation to be meaningful: `n_samples >>> n_clusters`.

If this gets accepted in some form I'll make a second pull request with other information criterions best suited for K optimisation.
