### PR TITLE
Add Transformer.fit

### DIFF
--- a/src/data/transforms/minmax.rs
+++ b/src/data/transforms/minmax.rs
@@ -135,18 +135,9 @@ impl<T: Float> Transformer<Matrix<T>> for MinMaxScaler<T> {
     }
 
     fn transform(&mut self, mut inputs: Matrix<T>) -> Result<Matrix<T>, Error> {
-        match (&self.scale_factors, &self.const_factors) {
+        if let (&None, &None) = (&self.scale_factors, &self.const_factors) {
             // if Transformer is not fitted to the data, fit for backward-compat.
-            (&None, &None) => {
-                let res = self.fit(&inputs);
-                match res {
-                    Err(err) => {
-                        return Err(err);
-                    },
-                    _ => {}
-                }
-            },
-            _ => {}
+            try!(self.fit(&inputs));
         }
 
         if let (&Some(ref scales), &Some(ref consts)) = (&self.scale_factors, &self.const_factors) {

--- a/src/data/transforms/mod.rs
+++ b/src/data/transforms/mod.rs
@@ -6,7 +6,7 @@
 //! The `Transformer` trait provides a shared interface for all of the
 //! data preprocessing transformations in rusty-machine.
 //!
-//! The transformers provide preprocessing transformations which are 
+//! The transformers provide preprocessing transformations which are
 //! commonly used in machine learning.
 
 pub mod minmax;
@@ -21,6 +21,8 @@ pub use self::standardize::Standardizer;
 
 /// Trait for data transformers
 pub trait Transformer<T> {
+    /// Fit Transformer to input data, and stores the transformation in the Transformer
+    fn fit(&mut self, inputs: &T) -> Result<(), error::Error>;
     /// Transforms the inputs and stores the transformation in the Transformer
     fn transform(&mut self, inputs: T) -> Result<T, error::Error>;
 }

--- a/src/data/transforms/shuffle.rs
+++ b/src/data/transforms/shuffle.rs
@@ -78,7 +78,7 @@ impl<R: Rng, T> Transformer<Matrix<T>> for Shuffler<R> {
 
     #[allow(unused_variables)]
     fn fit(&mut self, inputs: &Matrix<T>) -> Result<(), Error> {
-        unimplemented!();
+        Ok(())
     }
 
     fn transform(&mut self, mut inputs: Matrix<T>) -> LearningResult<Matrix<T>> {
@@ -123,5 +123,17 @@ mod tests {
 
         assert_eq!(shuffled.into_vec(),
                    vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
+    }
+
+    #[test]
+    fn shuffle_fit() {
+        let rng = StdRng::from_seed(&[1, 2, 3]);
+        let mut shuffler = Shuffler::new(rng);
+
+        // no op
+        let mat = Matrix::new(4, 2, vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
+        let res = shuffler.fit(&mat).unwrap();
+
+        assert_eq!(res, ());
     }
 }

--- a/src/data/transforms/shuffle.rs
+++ b/src/data/transforms/shuffle.rs
@@ -22,6 +22,7 @@
 //! ```
 
 use learning::LearningResult;
+use learning::error::Error;
 use linalg::{Matrix, BaseMatrix, BaseMatrixMut};
 use super::Transformer;
 
@@ -74,6 +75,12 @@ impl Default for Shuffler<ThreadRng> {
 ///
 /// Under the hood this uses a Fisher-Yates shuffle.
 impl<R: Rng, T> Transformer<Matrix<T>> for Shuffler<R> {
+
+    #[allow(unused_variables)]
+    fn fit(&mut self, inputs: &Matrix<T>) -> Result<(), Error> {
+        unimplemented!();
+    }
+
     fn transform(&mut self, mut inputs: Matrix<T>) -> LearningResult<Matrix<T>> {
         let n = inputs.rows();
 

--- a/src/data/transforms/standardize.rs
+++ b/src/data/transforms/standardize.rs
@@ -108,18 +108,9 @@ impl<T: Float + FromPrimitive> Transformer<Matrix<T>> for Standardizer<T> {
     }
 
     fn transform(&mut self, mut inputs: Matrix<T>) -> Result<Matrix<T>, Error> {
-        match (&self.means, &self.variances) {
+        if let (&None, &None) = (&self.means, &self.variances) {
             // if Transformer is not fitted to the data, fit for backward-compat.
-            (&None, &None) => {
-                let res = self.fit(&inputs);
-                match res {
-                    Err(err) => {
-                        return Err(err);
-                    },
-                    _ => {}
-                }
-            },
-            _ => {}
+            try!(self.fit(&inputs));
         }
 
         if let (&Some(ref means), &Some(ref variances)) = (&self.means, &self.variances) {


### PR DESCRIPTION
Based on the discussion in #158, added ``.fit`` method to ``Transformer``. This also allows basic transformers to fit to training data and transform test data.

Needs to decide:

- ``Shuffler`` doesn't needs to be ``fit``. There is an option to split ``Transformer`` depending on needs to fit, but I feel it is complex rather than convenient from user's point of view.
- To keep backward compat, ``.transform`` internally calls ``.fit`` if it is not fitted yet. Or should this be breaking change to force users to call ``.fit`` first.
- Is it ok to change ``MinMaxScaler`` to store trained data as ``Vector`` rather than ``Vec``, which should be compat with others.

Once decisions are made, let me add tests to validate changes.