### PR TITLE
Linear Regressor now returns error instead of panicking

### DIFF
--- a/src/learning/lin_reg.rs
+++ b/src/learning/lin_reg.rs
@@ -87,8 +87,7 @@ impl SupModel<Matrix<f64>, Vector<f64>> for LinRegressor {
         let full_inputs = ones.hcat(inputs);
 
         let xt = full_inputs.transpose();
-        self.parameters = Some((&xt * full_inputs).solve(&xt * targets)
-                                                  .expect("Unable to solve linear equation."));
+        self.parameters = Some((&xt * full_inputs).solve(&xt * targets)?);
         Ok(())
     }
 

--- a/tests/learning/lin_reg.rs
+++ b/tests/learning/lin_reg.rs
@@ -71,3 +71,14 @@ fn test_regression_datasets_trees() {
                         53.899328875510534, 53.899328875510534, 68.51530482306926];
     assert_eq!(predicted, Vector::new(expected));
 }
+
+#[test]
+fn test_train_no_data() {
+    let inputs = Matrix::new(0, 1, vec![]);
+    let targets = Vector::new(vec![]);
+
+    let mut lin_mod = LinRegressor::default();
+    let res = lin_mod.train(&inputs, &targets);
+
+    assert!(res.is_err());
+}


### PR DESCRIPTION
Before Linear Regressor would panic on ill-conditioned data, now it actually returns it as a result.