### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/learning/naive_bayes.rs
+++ b/src/learning/naive_bayes.rs
@@ -186,7 +186,7 @@ impl<T: Distribution> NaiveBayes<T> {
 
     fn find_class(row: &[f64]) -> LearningResult<usize> {
         // Find the `1` entry in the row
-        for (idx, r) in row.into_iter().enumerate() {
+        for (idx, r) in row.iter().enumerate() {
             if *r == 1f64 {
                 return Ok(idx);
             }
@@ -288,7 +288,7 @@ impl Distribution for Gaussian {
         let class_count = class_prior.len();
         let mut log_lik = Vec::with_capacity(class_count);
 
-        for (i, item) in class_prior.into_iter().enumerate() {
+        for (i, item) in class_prior.iter().enumerate() {
             let joint_i = item.ln();
             let n_ij = -0.5 * (self.sigma.select_rows(&[i]) * 2.0 * PI).apply(&|x| x.ln()).sum();
 
@@ -371,7 +371,7 @@ impl Distribution for Bernoulli {
         let mut per_class_row = Vec::with_capacity(class_count);
         let neg_prob_sum = neg_prob.sum_cols();
 
-        for (idx, p) in class_prior.into_iter().enumerate() {
+        for (idx, p) in class_prior.iter().enumerate() {
             per_class_row.push(p.ln() + neg_prob_sum[idx]);
         }
 

--- a/src/learning/toolkit/regularization.rs
+++ b/src/learning/toolkit/regularization.rs
@@ -117,7 +117,7 @@ mod tests {
         assert!((a - (42f64 / 12f64)) < 1e-18);
 
         let true_grad = vec![-1., -1., -1., 1., 1., 1., 1., 1., 1., 1., 1., 1.]
-            .into_iter()
+            .iter()
             .map(|x| x / 12f64)
             .collect::<Vec<_>>();
 
@@ -158,7 +158,7 @@ mod tests {
 
         let l1_true_grad = Matrix::new(3, 4,
             vec![-1., -1., -1., 1., 1., 1., 1., 1., 1., 1., 1., 1.]
-            .into_iter()
+            .iter()
             .map(|x| x / 12f64)
             .collect::<Vec<_>>());
         let l2_true_grad = &input_mat / 12f64;


### PR DESCRIPTION
Use `slice::iter` instead of `into_iter` to avoid future breakage

`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.